### PR TITLE
added File Read/Write error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ bench-folder*
 *.roc-format-failed
 *.roc-format-failed-ast-after
 *.roc-format-failed-ast-before
+
+# Tests
+file-test

--- a/file-test.roc
+++ b/file-test.roc
@@ -1,0 +1,69 @@
+app "file-test"
+    packages { pf: "src/main.roc" }
+    imports [
+        pf.Stdout,
+        pf.Task.{ Task },
+        pf.File.{ WriteErr },
+        pf.Path.{ Path },
+    ]
+    provides [main] to pf
+
+# Should print the following to the terminal
+# ```
+# Pass: expected NotFound
+# Pass: expected PermissionDenied
+# Pass: expected NotFound
+# Pass: expected PermissionDenied
+# Tests complete
+# ```
+main : Task {} []
+main =
+    {} <- attemptWriteTaskShouldError (File.writeUtf8 (Path.fromStr "/asdf/asdf/asdf/asdf.txt") "str") "NotFound" |> Task.await
+    {} <- attemptWriteTaskShouldError (File.writeUtf8 (Path.fromStr "/System/asdf") "str") "PermissionDenied" |> Task.await
+
+    {} <- attemptReadTaskShouldError (File.readUtf8 (Path.fromStr "/asdf/asdf/asdf/asdf.txt")) "NotFound" |> Task.await
+    {} <- attemptReadTaskShouldError (File.readUtf8 (Path.fromStr "/etc/master.passwd")) "PermissionDenied" |> Task.await
+
+    Stdout.line "Tests complete"
+
+# File Writing test helpers
+attemptWriteTaskShouldError = \task, error ->
+    Task.attempt task \result ->
+        when result is
+            Ok {} ->
+                Stdout.line (Str.concat "Fail: expected " error)
+
+            Err (FileWriteErr _ err) ->
+                got = File.writeErrToStr err
+
+                if got == error then
+                    Stdout.line (Str.concat "Pass: expected " got)
+                else
+                    msg = ["Fail: expected ", error, " got ", got] |> Str.joinWith ""
+
+                    Stdout.line msg
+
+# File Reading test helpers
+attemptReadTaskShouldError = \task, error ->
+    Task.attempt task \result ->
+        when result is
+            Ok _ ->
+                Stdout.line (Str.concat "Fail: expected " error)
+
+            Err (FileReadErr _ err) ->
+                got = File.readErrToStr err
+
+                if got == error then
+                    Stdout.line (Str.concat "Pass: expected " got)
+                else
+                    msg = ["Fail: expected ", error, " got ", got] |> Str.joinWith ""
+
+                    Stdout.line msg
+
+            Err (FileReadUtf8Err _ _) ->
+                if error == "FileReadUtf8Err" then
+                    Stdout.line "Pass: expected FileReadUtf8Err"
+                else
+                    msg = ["Fail: expected ", error, " got FileReadUtf8Err"] |> Str.joinWith ""
+
+                    Stdout.line msg

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -474,6 +474,7 @@ dependencies = [
 [[package]]
 name = "roc_std"
 version = "0.0.1"
+source = "git+https://github.com/roc-lang/roc#bb89344eaab6cb03d52246a99e65294e79be87dd"
 dependencies = [
  "arrayvec",
  "static_assertions",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -17,7 +17,7 @@ name = "host"
 path = "src/main.rs"
 
 [dependencies]
-roc_std = { path = "../../../crates/roc_std" }
+roc_std = { git = "https://github.com/roc-lang/roc" }
 libc = "0.2"
 backtrace = "0.3"
 reqwest = { version="0.11.11", default-features=false, features=["blocking", "rustls-tls"] }

--- a/src/File.roc
+++ b/src/File.roc
@@ -1,5 +1,5 @@
 interface File
-    exposes [ReadErr, WriteErr, write, writeUtf8, writeBytes, readUtf8, readBytes, delete]
+    exposes [ReadErr, WriteErr, write, writeUtf8, writeBytes, readUtf8, readBytes, delete, writeErrToStr, readErrToStr]
     imports [Task.{ Task }, InternalTask, InternalFile, Path.{ Path }, InternalPath, Effect.{ Effect }]
 
 ReadErr : InternalFile.ReadErr
@@ -142,3 +142,42 @@ toReadTask = \path, toEffect ->
     |> toEffect
     |> InternalTask.fromEffect
     |> Task.mapFail \err -> FileReadErr path err
+
+writeErrToStr : WriteErr -> Str
+writeErrToStr = \err ->
+    when err is
+        NotFound -> "NotFound"
+        Interrupted -> "Interrupted"
+        InvalidFilename -> "InvalidFilename"
+        PermissionDenied -> "PermissionDenied"
+        TooManySymlinks -> "TooManySymlinks"
+        TooManyHardlinks -> "TooManyHardlinks"
+        TimedOut -> "TimedOut"
+        StaleNetworkFileHandle -> "StaleNetworkFileHandle"
+        ReadOnlyFilesystem -> "ReadOnlyFilesystem"
+        AlreadyExists -> "AlreadyExists"
+        WasADirectory -> "WasADirectory"
+        WriteZero -> "WriteZero"
+        StorageFull -> "StorageFull"
+        FilesystemQuotaExceeded -> "FilesystemQuotaExceeded"
+        FileTooLarge -> "FileTooLarge"
+        ResourceBusy -> "ResourceBusy"
+        ExecutableFileBusy -> "ExecutableFileBusy"
+        OutOfMemory -> "OutOfMemory"
+        Unsupported -> "Unsupported"
+        _ -> "Unrecognized"
+
+readErrToStr : ReadErr -> Str
+readErrToStr = \err ->
+    when err is
+        NotFound -> "NotFound"
+        Interrupted -> "Interrupted"
+        InvalidFilename -> "InvalidFilename"
+        PermissionDenied -> "PermissionDenied"
+        TooManySymlinks -> "TooManySymlinks"
+        TooManyHardlinks -> "TooManyHardlinks"
+        TimedOut -> "TimedOut"
+        StaleNetworkFileHandle -> "StaleNetworkFileHandle"
+        OutOfMemory -> "OutOfMemory"
+        Unsupported -> "Unsupported"
+        _ -> "Unrecognized"


### PR DESCRIPTION

Added error handling for file reads and writes, and a roc app to test this. Note roc app likely only works on MacOS as it depends on hardcoded folders/files being present to trigger specific errors. 
```
luke@192-168-1-108 basic-cli % roc run file-test.roc                                  
🔨 Rebuilding platform...
Pass: expected NotFound
Pass: expected PermissionDenied
Pass: expected NotFound
Pass: expected PermissionDenied
Tests complete
```