### PR TITLE
Expose error types from Tcp module

### DIFF
--- a/src/Tcp.roc
+++ b/src/Tcp.roc
@@ -8,7 +8,9 @@ interface Tcp
         readLine,
         write,
         writeUtf8,
+        ConnectErr,
         connectErrToStr,
+        StreamErr,
         streamErrToStr,
     ]
     imports [Effect, Task.{ Task }, InternalTask, InternalTcp]


### PR DESCRIPTION
Exposing  `Tcp` error types so that the user can write `Task` annotations.