### PR TITLE
Add `Task.batch` and example

### DIFF
--- a/ci/expect_scripts/record-builer.exp
+++ b/ci/expect_scripts/record-builer.exp
@@ -1,0 +1,16 @@
+#!/usr/bin/expect
+
+# uncomment line below for debugging
+# exp_internal 1
+
+set timeout 7
+
+spawn ./roc_nightly/roc run ./examples/record-builder.roc --prebuilt-platform
+
+expect "Apples: Granny Smith, Pink Lady, Golden Delicious\r\nOranges: Navel, Blood Orange, Clementine\r\n" {
+  expect eof
+  exit 0
+}
+
+puts stderr "\nError: output was different from expected value."
+exit 1

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -9,3 +9,4 @@ env
 out.txt
 tcp-client
 time
+record-builder

--- a/examples/record-builder.roc
+++ b/examples/record-builder.roc
@@ -9,7 +9,6 @@ app "record-builder"
     provides [main] to pf
 
 main =
-
     myrecord : Task { apples : List Str, oranges : List Str } []
     myrecord = Task.succeed {
         apples: <- getFruit Apples |> Task.batch,

--- a/examples/record-builder.roc
+++ b/examples/record-builder.roc
@@ -1,0 +1,32 @@
+app "record-builder"
+    packages {
+        pf: "../src/main.roc",
+    }
+    imports [
+        pf.Stdout,
+        pf.Task.{ Task },
+    ]
+    provides [main] to pf
+
+main =
+
+    myrecord : Task { apples : List Str, oranges : List Str } []
+    myrecord = Task.succeed {
+        apples: <- getFruit Apples |> Task.batch,
+        oranges: <- getFruit Oranges |> Task.batch,
+    }
+
+    { apples, oranges } <- myrecord |> Task.await
+
+    "Apples: "
+    |> Str.concat (Str.joinWith apples ", ")
+    |> Str.concat "\n"
+    |> Str.concat "Oranges: "
+    |> Str.concat (Str.joinWith oranges ", ")
+    |> Stdout.line
+
+getFruit : [Apples, Oranges] -> Task (List Str) []
+getFruit = \request ->
+    when request is
+        Apples -> Task.succeed ["Granny Smith", "Pink Lady", "Golden Delicious"]
+        Oranges -> Task.succeed ["Navel", "Blood Orange", "Clementine"]

--- a/src/Task.roc
+++ b/src/Task.roc
@@ -1,5 +1,18 @@
 interface Task
-    exposes [Task, succeed, fail, await, map, mapFail, onFail, attempt, forever, loop, fromResult]
+    exposes [
+        Task,
+        succeed,
+        fail,
+        await,
+        map,
+        mapFail,
+        onFail,
+        attempt,
+        forever,
+        loop,
+        fromResult,
+        batch,
+    ]
     imports [Effect, InternalTask]
 
 Task ok err : InternalTask.Task ok err
@@ -100,3 +113,9 @@ fromResult = \result ->
     when result is
         Ok ok -> succeed ok
         Err err -> fail err
+
+batch : Task a err -> (Task (a -> b) err -> Task b err)
+batch = \current -> \next ->
+        f <- next |> await
+
+        map current f


### PR DESCRIPTION
This PR adds `Task.batch` to enable applicative style use of Tasks.

Also relevant [zulip discusion](https://roc.zulipchat.com/#narrow/stream/231634-beginners/topic/Task.20apply/near/365000245)