### PR TITLE
Upgrade Stdin from `byte` to `bytes` add support for terminal raw mode

### DIFF
--- a/examples/stdin.roc
+++ b/examples/stdin.roc
@@ -4,7 +4,7 @@ app "time"
         pf.Stdout,
         pf.Stderr,
         pf.Stdin,
-        pf.Task.{Task},
+        pf.Task.{ Task },
     ]
     provides [main] to pf
 
@@ -15,17 +15,22 @@ main =
         Stderr.line "Expected a series of number characters (0-9)"
     else
         when Str.fromUtf8 numberBytes is
-            Ok nStr -> 
+            Ok nStr ->
                 Stdout.line "Got number \(nStr)"
+
             Err _ ->
                 Stderr.line "Error, bad utf8"
 
 takeNumberBytes : Task (List U8) *
-takeNumberBytes = 
-    Task.loop [] \bytes ->
-        b <- Stdin.byte |> Task.await
-        
-        if b >= '0' && b <= '9' then 
-            Task.succeed (Step (List.append bytes b))
-        else 
-            Task.succeed (Done bytes)
+takeNumberBytes =
+
+    bytesRead <- Stdin.bytes |> Task.await
+
+    numberBytes =
+        List.walk bytesRead [] \bytes, b ->
+            if b >= '0' && b <= '9' then
+                List.append bytes b
+            else
+                bytes
+
+    Task.succeed numberBytes

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -51,6 +51,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +79,31 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "crossterm"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -191,6 +222,7 @@ name = "host"
 version = "0.0.1"
 dependencies = [
  "backtrace",
+ "crossterm",
  "libc",
  "reqwest",
  "roc_std",
@@ -315,6 +347,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +424,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +480,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -514,6 +588,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +633,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +670,12 @@ checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
@@ -860,12 +976,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -874,10 +1011,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -886,16 +1035,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -21,5 +21,6 @@ roc_std = { git = "https://github.com/roc-lang/roc", rev = "e549c8b" }
 libc = "0.2"
 backtrace = "0.3"
 reqwest = { version="0.11.11", default-features=false, features=["blocking", "rustls-tls"] }
+crossterm = "0.26.1"
 
 [workspace]

--- a/src/Effect.roc
+++ b/src/Effect.roc
@@ -18,7 +18,9 @@ hosted Effect
         stderrLine,
         stderrWrite,
         stdinLine,
-        stdinByte,
+        stdinBytes,
+        ttyModeCanonical,
+        ttyModeRaw,
         sendRequest,
         fileReadBytes,
         fileDelete,
@@ -42,7 +44,9 @@ stdoutWrite : Str -> Effect {}
 stderrLine : Str -> Effect {}
 stderrWrite : Str -> Effect {}
 stdinLine : Effect Str
-stdinByte : Effect U8
+stdinBytes : Effect (List U8)
+ttyModeCanonical : Effect {}
+ttyModeRaw : Effect {}
 
 fileWriteBytes : List U8, List U8 -> Effect (Result {} InternalFile.WriteErr)
 fileWriteUtf8 : List U8, Str -> Effect (Result {} InternalFile.WriteErr)

--- a/src/Stdin.roc
+++ b/src/Stdin.roc
@@ -17,9 +17,11 @@ line =
     |> Effect.map Ok
     |> InternalTask.fromEffect
 
-## Read a single byte from [standard input](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)).
+## Read bytes from [standard input](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)).
 ##
-## > This task will block the program from continuing until `stdin` receives a byte.
+## > This is typically used in combintation with [Tty.enableRawMode], 
+## which disables defaults terminal bevahiour and allows reading input
+## without buffering until Enter key is pressed.
 bytes : Task (List U8) *
 bytes =
     Effect.stdinBytes

--- a/src/Stdin.roc
+++ b/src/Stdin.roc
@@ -1,5 +1,8 @@
 interface Stdin
-    exposes [line, byte]
+    exposes [
+        line, 
+        bytes, 
+    ]
     imports [Effect, Task.{ Task }, InternalTask]
 
 ## Read a line from [standard input](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)).
@@ -17,8 +20,8 @@ line =
 ## Read a single byte from [standard input](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)).
 ##
 ## > This task will block the program from continuing until `stdin` receives a byte.
-byte : Task U8 *
-byte =
-    Effect.stdinByte
+bytes : Task (List U8) *
+bytes =
+    Effect.stdinBytes
     |> Effect.map Ok
     |> InternalTask.fromEffect

--- a/src/Tty.roc
+++ b/src/Tty.roc
@@ -1,18 +1,28 @@
+## Provides functionality to work with the terminal
 interface Tty
-    exposes [ 
+    exposes [
         disableRawMode,
         enableRawMode,
     ]
     imports [Effect, Task.{ Task }, InternalTask]
 
-disableRawMode : Task {} *
-disableRawMode =
-    Effect.ttyModeCanonical
-    |> Effect.map Ok
-    |> InternalTask.fromEffect
-
+## Enable terminal raw mode which disables some default terminal bevahiour.
+##
+## The following modes are disabled:
+## - Input will not be echo to the terminal screen
+## - Input will not be buffered until Enter key is pressed
+## - Input will not be line buffered (input sent byte-by-byte to input buffer)
+## - Special keys like Backspace and CTRL+C will not be processed by terminal driver
+##
 enableRawMode : Task {} *
 enableRawMode =
     Effect.ttyModeRaw
+    |> Effect.map Ok
+    |> InternalTask.fromEffect
+
+## Revert terminal to default behaviour
+disableRawMode : Task {} *
+disableRawMode =
+    Effect.ttyModeCanonical
     |> Effect.map Ok
     |> InternalTask.fromEffect

--- a/src/Tty.roc
+++ b/src/Tty.roc
@@ -1,0 +1,18 @@
+interface Tty
+    exposes [ 
+        disableRawMode,
+        enableRawMode,
+    ]
+    imports [Effect, Task.{ Task }, InternalTask]
+
+disableRawMode : Task {} *
+disableRawMode =
+    Effect.ttyModeCanonical
+    |> Effect.map Ok
+    |> InternalTask.fromEffect
+
+enableRawMode : Task {} *
+enableRawMode =
+    Effect.ttyModeRaw
+    |> Effect.map Ok
+    |> InternalTask.fromEffect

--- a/src/main.roc
+++ b/src/main.roc
@@ -17,6 +17,7 @@ platform "cli"
         Url,
         Utc,
         Sleep,
+        Tty,
     ]
     packages {}
     imports [Task.{ Task }]

--- a/src/src/lib.rs
+++ b/src/src/lib.rs
@@ -306,13 +306,14 @@ pub extern "C" fn roc_fx_stdinLine() -> RocStr {
 }
 
 #[no_mangle]
-pub extern "C" fn roc_fx_stdinByte() -> u8 {
+pub extern "C" fn roc_fx_stdinBytes() -> RocList<u8> {
     let stdin = std::io::stdin();
-    let mut byte: [u8; 1] = [0];
+    let mut buffer: [u8; 256] = [0; 256];
 
-    stdin.lock().read_exact(&mut byte).unwrap();
-
-    byte[0]
+    match stdin.lock().read(&mut buffer) {
+        Ok(bytes_read) => {RocList::from(&buffer[0..bytes_read])}
+        Err(_) => {RocList::from((&[]).as_slice())}
+    }
 }
 
 #[no_mangle]
@@ -339,6 +340,16 @@ pub extern "C" fn roc_fx_stderrWrite(text: &RocStr) {
     let string = text.as_str();
     eprint!("{}", string);
     std::io::stderr().flush().unwrap();
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_ttyModeCanonical() {
+    crossterm::terminal::disable_raw_mode().expect("failed to disable raw mode");
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_ttyModeRaw() {
+    crossterm::terminal::enable_raw_mode().expect("failed to enable raw mode");
 }
 
 // #[no_mangle]


### PR DESCRIPTION
This PR;
1. Cross-platform support for entering terminal raw mode using the [crossterm](https://github.com/crossterm-rs/crossterm) library, and 
2. Changes `Stdin.byte` to `Stdin.bytes` to read in up to 256 bytes from the input buffer as this is a much more useful function than processing a single byte at a time.
