### PR TITLE
Update Task module with `Task.ok` and `Task.err` to unify with Result API 

### DIFF
--- a/examples/countdown.roc
+++ b/examples/countdown.roc
@@ -1,6 +1,6 @@
 app "countdown"
     packages { pf: "../src/main.roc" }
-    imports [pf.Stdin, pf.Stdout, pf.Task.{ await, loop, succeed }]
+    imports [pf.Stdin, pf.Stdout, pf.Task.{ await, loop }]
     provides [main] to pf
 
 main =
@@ -11,8 +11,8 @@ main =
 tick = \n ->
     if n == 0 then
         _ <- await (Stdout.line "🎉 SURPRISE! Happy Birthday! 🎂")
-        succeed (Done {})
+        Task.ok (Done {})
     else
         _ <- await (n |> Num.toStr |> \s -> "\(s)..." |> Stdout.line)
         _ <- await Stdin.line
-        succeed (Step (n - 1))
+        Task.ok (Step (n - 1))

--- a/examples/http-get.roc
+++ b/examples/http-get.roc
@@ -18,7 +18,7 @@ main =
     }
 
     output <- Http.send request
-        |> Task.onFail (\err -> err |> Http.errorToString |> Task.succeed)
+        |> Task.onFail (\err -> err |> Http.errorToString |> Task.ok)
         |> Task.await
 
     Stdout.line output

--- a/examples/http-get.roc
+++ b/examples/http-get.roc
@@ -18,7 +18,7 @@ main =
     }
 
     output <- Http.send request
-        |> Task.onFail (\err -> err |> Http.errorToString |> Task.ok)
+        |> Task.onErr (\err -> err |> Http.errorToString |> Task.ok)
         |> Task.await
 
     Stdout.line output

--- a/examples/record-builder.roc
+++ b/examples/record-builder.roc
@@ -23,7 +23,7 @@ main =
     |> Str.concat "Oranges: "
     |> Str.concat (Str.joinWith oranges ", ")
     |> Stdout.line
-    |> Task.mapFail \_ -> 1
+    |> Task.mapErr \_ -> 1
 
 getFruit : [Apples, Oranges] -> Task (List Str) *
 getFruit = \request ->

--- a/examples/record-builder.roc
+++ b/examples/record-builder.roc
@@ -10,7 +10,7 @@ app "record-builder"
 
 main =
     myrecord : Task { apples : List Str, oranges : List Str } U32
-    myrecord = Task.succeed {
+    myrecord = Task.ok {
         apples: <- getFruit Apples |> Task.batch,
         oranges: <- getFruit Oranges |> Task.batch,
     }
@@ -28,5 +28,5 @@ main =
 getFruit : [Apples, Oranges] -> Task (List Str) *
 getFruit = \request ->
     when request is
-        Apples -> Task.succeed ["Granny Smith", "Pink Lady", "Golden Delicious"]
-        Oranges -> Task.succeed ["Navel", "Blood Orange", "Clementine"]
+        Apples -> Task.ok ["Granny Smith", "Pink Lady", "Golden Delicious"]
+        Oranges -> Task.ok ["Navel", "Blood Orange", "Clementine"]

--- a/examples/stdin.roc
+++ b/examples/stdin.roc
@@ -33,4 +33,4 @@ takeNumberBytes =
             else
                 bytes
 
-    Task.succeed numberBytes
+    Task.ok numberBytes

--- a/src/File.roc
+++ b/src/File.roc
@@ -146,14 +146,14 @@ toWriteTask = \path, toEffect ->
     InternalPath.toBytes path
     |> toEffect
     |> InternalTask.fromEffect
-    |> Task.mapFail \err -> FileWriteErr path err
+    |> Task.mapErr \err -> FileWriteErr path err
 
 toReadTask : Path, (List U8 -> Effect (Result ok err)) -> Task ok [FileReadErr Path err]
 toReadTask = \path, toEffect ->
     InternalPath.toBytes path
     |> toEffect
     |> InternalTask.fromEffect
-    |> Task.mapFail \err -> FileReadErr path err
+    |> Task.mapErr \err -> FileReadErr path err
 
 ## Converts a [WriteErr] to a [Str].
 writeErrToStr : WriteErr -> Str

--- a/src/InternalTask.roc
+++ b/src/InternalTask.roc
@@ -1,14 +1,14 @@
 interface InternalTask
-    exposes [Task, fromEffect, toEffect, succeed, fail]
+    exposes [Task, fromEffect, toEffect, ok, err]
     imports [Effect.{ Effect }]
 
 Task ok err := Effect (Result ok err)
 
-succeed : ok -> Task ok *
-succeed = \ok -> @Task (Effect.always (Ok ok))
+ok : a -> Task a *
+ok = \a -> @Task (Effect.always (Ok a))
 
-fail : err -> Task * err
-fail = \err -> @Task (Effect.always (Err err))
+err : a -> Task * a
+err = \a -> @Task (Effect.always (Err a))
 
 fromEffect : Effect (Result ok err) -> Task ok err
 fromEffect = \effect -> @Task effect

--- a/src/Task.roc
+++ b/src/Task.roc
@@ -5,8 +5,8 @@ interface Task
         err,
         await,
         map,
-        mapFail,
-        onFail,
+        mapErr,
+        onErr,
         attempt,
         forever,
         loop,
@@ -61,7 +61,7 @@ loop = \state, step ->
 ok : a -> Task a *
 ok = \a -> InternalTask.ok a
 
-## Create a task that always failes with the error provided.
+## Create a task that always fails with the error provided.
 ##
 ## ```
 ## # Always fails with the tag `CustomError Str`
@@ -133,10 +133,10 @@ await = \task, transform ->
 ## ```
 ## # Prints "Something went wrong!" to standard error if `canFail` fails.
 ## canFail
-## |> Task.onFail \_ -> Stderr.line "Something went wrong!"
+## |> Task.onErr \_ -> Stderr.line "Something went wrong!"
 ## ```
-onFail : Task a b, (b -> Task a c) -> Task a c
-onFail = \task, transform ->
+onErr : Task a b, (b -> Task a c) -> Task a c
+onErr = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
         \result ->
@@ -169,10 +169,10 @@ map = \task, transform ->
 ## ```
 ## # Ignore the fail value, and map it to the tag `CustomError`
 ## canFail
-## |> Task.mapFail \_ -> CustomError
+## |> Task.mapErr \_ -> CustomError
 ## ```
-mapFail : Task c a, (a -> b) -> Task c b
-mapFail = \task, transform ->
+mapErr : Task c a, (a -> b) -> Task c b
+mapErr = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
         \result ->

--- a/src/Task.roc
+++ b/src/Task.roc
@@ -1,8 +1,8 @@
 interface Task
     exposes [
         Task,
-        succeed,
-        fail,
+        ok,
+        err,
         await,
         map,
         mapFail,
@@ -20,7 +20,7 @@ interface Task
 Task ok err : InternalTask.Task ok err
 
 ## Run a task that never ends. Note that this task does not return a value.
-forever : Task val err -> Task * err
+forever : Task a err -> Task * err
 forever = \task ->
     looper = \{} ->
         task
@@ -55,22 +55,22 @@ loop = \state, step ->
 ## ```
 ## # Always succeeds with "Louis"
 ## getName : Task.Task Str *
-## getName = Task.succeed "Louis"
+## getName = Task.ok "Louis"
 ## ```
 ##
-succeed : ok -> Task ok *
-succeed = \ok -> InternalTask.succeed ok
+ok : a -> Task a *
+ok = \a -> InternalTask.ok a
 
 ## Create a task that always failes with the error provided.
 ##
 ## ```
 ## # Always fails with the tag `CustomError Str`
 ## customError : Str -> Task.Task {} [CustomError Str]
-## customError = \err -> Task.fail (CustomError err)
+## customError = \err -> Task.err (CustomError err)
 ## ```
 ##
-fail : err -> Task * err
-fail = \err -> InternalTask.fail err
+err : a -> Task * a
+err = \a -> InternalTask.err a
 
 ## Transform a given Task with a function that handles the success or error case
 ## and returns another task based on that. This is useful for chaining tasks
@@ -101,8 +101,8 @@ attempt = \task, transform ->
         (InternalTask.toEffect task)
         \result ->
             when result is
-                Ok ok -> transform (Ok ok) |> InternalTask.toEffect
-                Err err -> transform (Err err) |> InternalTask.toEffect
+                Ok a -> transform (Ok a) |> InternalTask.toEffect
+                Err b -> transform (Err b) |> InternalTask.toEffect
 
     InternalTask.fromEffect effect
 
@@ -115,16 +115,16 @@ attempt = \task, transform ->
 ## {} <- Stdout.write "Hello "|> Task.await
 ## {} <- Stdout.srite "World!\n"|> Task.await
 ##
-## Task.succeed {}
+## Task.ok {}
 ## ```
-await : Task a err, (a -> Task b err) -> Task b err
+await : Task a b, (a -> Task c b) -> Task c b
 await = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
         \result ->
             when result is
                 Ok a -> transform a |> InternalTask.toEffect
-                Err err -> fail err |> InternalTask.toEffect
+                Err b -> Task.err b |> InternalTask.toEffect
 
     InternalTask.fromEffect effect
 
@@ -135,14 +135,14 @@ await = \task, transform ->
 ## canFail
 ## |> Task.onFail \_ -> Stderr.line "Something went wrong!"
 ## ```
-onFail : Task ok a, (a -> Task ok b) -> Task ok b
+onFail : Task a b, (b -> Task a c) -> Task a c
 onFail = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
         \result ->
             when result is
-                Ok a -> succeed a |> InternalTask.toEffect
-                Err err -> transform err |> InternalTask.toEffect
+                Ok a -> Task.ok a |> InternalTask.toEffect
+                Err b -> transform b |> InternalTask.toEffect
 
     InternalTask.fromEffect effect
 
@@ -150,17 +150,17 @@ onFail = \task, transform ->
 ##
 ## ```
 ## # Succeeds with a value of "Bonjour Louis!"
-## Task.succeed "Louis"
+## Task.ok "Louis"
 ## |> Task.map (\name -> "Bonjour \(name)!")
 ## ```
-map : Task a err, (a -> b) -> Task b err
+map : Task a c, (a -> b) -> Task b c
 map = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
         \result ->
             when result is
-                Ok ok -> succeed (transform ok) |> InternalTask.toEffect
-                Err err -> fail err |> InternalTask.toEffect
+                Ok a -> Task.ok (transform a) |> InternalTask.toEffect
+                Err b -> Task.err b |> InternalTask.toEffect
 
     InternalTask.fromEffect effect
 
@@ -171,23 +171,23 @@ map = \task, transform ->
 ## canFail
 ## |> Task.mapFail \_ -> CustomError
 ## ```
-mapFail : Task ok a, (a -> b) -> Task ok b
+mapFail : Task c a, (a -> b) -> Task c b
 mapFail = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
         \result ->
             when result is
-                Ok ok -> succeed ok |> InternalTask.toEffect
-                Err err -> fail (transform err) |> InternalTask.toEffect
+                Ok c -> Task.ok c |> InternalTask.toEffect
+                Err a -> Task.err (transform a) |> InternalTask.toEffect
 
     InternalTask.fromEffect effect
 
 ## Use a Result among other Tasks by converting it into a [Task].
-fromResult : Result ok err -> Task ok err
+fromResult : Result a b -> Task a b
 fromResult = \result ->
     when result is
-        Ok ok -> succeed ok
-        Err err -> fail err
+        Ok a -> Task.ok a
+        Err b -> Task.err b
 
 ## Apply a task to another task applicatively. This can be used with
 ## [succeed] to build a [Task] that returns a record.
@@ -198,12 +198,12 @@ fromResult = \result ->
 ##
 ## ```
 ## getFruitBasket : Task { apples : List Str, oranges : List Str } [NoFruitAvailable]
-## getFruitBasket = Task.succeed {
+## getFruitBasket = Task.ok {
 ##     apples: <- getFruit Apples |> Task.batch,
 ##     oranges: <- getFruit Oranges |> Task.batch,
 ## }
 ## ```
-batch : Task a err -> (Task (a -> b) err -> Task b err)
+batch : Task a c -> (Task (a -> b) c -> Task b c)
 batch = \current -> \next ->
         f <- next |> await
 

--- a/src/Tcp.roc
+++ b/src/Tcp.roc
@@ -50,7 +50,7 @@ withConnect = \hostname, port, callback ->
         |> Task.onFail
             (\err ->
                 _ <- close stream |> Task.await
-                Task.fail err
+                Task.err err
             )
         |> Task.await
 

--- a/src/Tcp.roc
+++ b/src/Tcp.roc
@@ -42,12 +42,12 @@ StreamErr : InternalTcp.StreamErr
 withConnect : Str, U16, (Stream -> Task {} err) -> Task {} [TcpConnectErr ConnectErr, TcpPerformErr err]
 withConnect = \hostname, port, callback ->
     stream <- connect hostname port
-        |> Task.mapFail TcpConnectErr
+        |> Task.mapErr TcpConnectErr
         |> Task.await
 
     {} <- callback stream
-        |> Task.mapFail TcpPerformErr
-        |> Task.onFail
+        |> Task.mapErr TcpPerformErr
+        |> Task.onErr
             (\err ->
                 _ <- close stream |> Task.await
                 Task.err err
@@ -82,7 +82,7 @@ readUpTo = \bytesToRead, stream ->
     Effect.tcpReadUpTo bytesToRead stream
     |> Effect.map InternalTcp.fromReadResult
     |> InternalTask.fromEffect
-    |> Task.mapFail TcpReadErr
+    |> Task.mapErr TcpReadErr
 
 ## Read an exact number of bytes or fail. 
 ##
@@ -125,7 +125,7 @@ readUntil = \byte, stream ->
     Effect.tcpReadUntil byte stream
     |> Effect.map InternalTcp.fromReadResult
     |> InternalTask.fromEffect
-    |> Task.mapFail TcpReadErr
+    |> Task.mapErr TcpReadErr
 
 ## Read until a newline or EOF is reached. 
 ##
@@ -158,7 +158,7 @@ write = \bytes, stream ->
     Effect.tcpWrite bytes stream
     |> Effect.map InternalTcp.fromWriteResult
     |> InternalTask.fromEffect
-    |> Task.mapFail TcpWriteErr
+    |> Task.mapErr TcpWriteErr
 
 ## Writes a [Str] to a TCP stream, encoded as [UTF-8](https://en.wikipedia.org/wiki/UTF-8).
 ##


### PR DESCRIPTION
This PR updates Task to unify the API with Result. This change was discussed in [zulip thread](https://roc.zulipchat.com/#narrow/stream/304641-ideas/topic/Task.20and.20Result.20onErr/near/368724849).

- `Task.succeed` -> `Task.ok`
- `Task.fail` -> `Task.err`
- `Task.mapFail` -> `Task.mapErr`
- `Task.onFail` -> `Task.onErr`
