### PR TITLE
Modify main return from U32 to I32

### DIFF
--- a/examples/args.roc
+++ b/examples/args.roc
@@ -3,7 +3,7 @@ app "args"
     imports [pf.Stdout, pf.Arg, pf.Task.{ Task }, pf.Process]
     provides [main] to pf
 
-main : Task {} U32
+main : Task {} I32
 main =
     args <- Arg.list |> Task.await
     parser =

--- a/examples/command.roc
+++ b/examples/command.roc
@@ -16,7 +16,7 @@ main =
 
 # Run "env" with verbose option, clear all environment variables, and pass in
 # "FOO" and "BAZ".
-first : Task {} U32
+first : Task {} I32
 first =
 
     result <-
@@ -38,7 +38,7 @@ first =
 
 # Run "stat" with environment variable "FOO" set to "BAR" and three arguments: "--format", "'%A'", and "LICENSE".
 # Capture stdout and stderr and print them.
-second : Task {} U32
+second : Task {} I32
 second =
     output <-
         Command.new "stat"

--- a/examples/echo.roc
+++ b/examples/echo.roc
@@ -3,13 +3,13 @@ app "echo"
     imports [pf.Stdin, pf.Stdout, pf.Task.{ Task }]
     provides [main] to pf
 
-main : Task {} U32
+main : Task {} I32
 main =
     _ <- Task.await (Stdout.line "🗣  Shout into this cave and hear the echo! 👂👂👂")
     Task.loop {} \_ ->
         Task.map tick Step
 
-tick : Task.Task {} U32
+tick : Task {} I32
 tick =
     shout <- Task.await Stdin.line
 

--- a/examples/env.roc
+++ b/examples/env.roc
@@ -3,7 +3,7 @@ app "env"
     imports [pf.Stdout, pf.Stderr, pf.Env, pf.Task.{ Task }]
     provides [main] to pf
 
-main : Task {} U32
+main : Task {} I32
 main =
     task =
         Env.decode "EDITOR"

--- a/examples/file-mixedBROKEN.roc
+++ b/examples/file-mixedBROKEN.roc
@@ -12,7 +12,7 @@ app "file-mixed"
     ]
     provides [main] to pf
 
-main : Task {} U32
+main : Task {} I32
 main =
     path = Path.fromStr "out.txt"
     task =

--- a/examples/file-read.roc
+++ b/examples/file-read.roc
@@ -10,7 +10,7 @@ app "file-read"
     ]
     provides [main] to pf
 
-main : Task {} U32
+main : Task {} I32
 main =
     fileName = "README.md"
     path = Path.fromStr fileName

--- a/examples/form.roc
+++ b/examples/form.roc
@@ -3,7 +3,7 @@ app "form"
     imports [pf.Stdin, pf.Stdout, pf.Task.{ await, Task }]
     provides [main] to pf
 
-main : Task {} U32
+main : Task {} I32
 main =
     _ <- await (Stdout.line "What's your first name?")
     firstName <- await Stdin.line

--- a/examples/http-get.roc
+++ b/examples/http-get.roc
@@ -3,7 +3,7 @@ app "http-get"
     imports [pf.Http, pf.Task.{ Task }, pf.Stdin, pf.Stdout]
     provides [main] to pf
 
-main : Task {} U32
+main : Task {} I32
 main =
     _ <- Task.await (Stdout.line "Enter a URL to fetch. It must contain a scheme like \"http://\" or \"https://\".")
 

--- a/examples/record-builder.roc
+++ b/examples/record-builder.roc
@@ -9,7 +9,7 @@ app "record-builder"
     provides [main] to pf
 
 main =
-    myrecord : Task { apples : List Str, oranges : List Str } U32
+    myrecord : Task { apples : List Str, oranges : List Str } I32
     myrecord = Task.succeed {
         apples: <- getFruit Apples |> Task.batch,
         oranges: <- getFruit Oranges |> Task.batch,

--- a/examples/stdin.roc
+++ b/examples/stdin.roc
@@ -1,4 +1,4 @@
-app "time"
+app "example-stdin"
     packages { pf: "../src/main.roc" }
     imports [
         pf.Stdout,
@@ -9,6 +9,7 @@ app "time"
     provides [main] to pf
 
 main =
+    {} <- Stdout.line "Enter a series of number characters (0-9):" |> Task.await
     numberBytes <- takeNumberBytes |> Task.await
 
     if List.isEmpty numberBytes then

--- a/examples/tcp-client.roc
+++ b/examples/tcp-client.roc
@@ -3,7 +3,7 @@ app "tcp-client"
     imports [pf.Tcp, pf.Task.{ Task, await }, pf.Stdout, pf.Stdin, pf.Stderr, pf.Process]
     provides [main] to pf
 
-main : Task {} U32
+main : Task {} I32
 main =
     task =
         stream <- Tcp.withConnect "127.0.0.1" 8085

--- a/file-testBROKEN.roc
+++ b/file-testBROKEN.roc
@@ -16,7 +16,7 @@ app "file-test"
 # Pass: expected PermissionDenied
 # Tests complete
 # ```
-main : Task {} U32
+main : Task {} I32
 main =
     {} <- attemptWriteTaskShouldError (File.writeUtf8 (Path.fromStr "/asdf/asdf/asdf/asdf.txt") "str") "NotFound" |> Task.await
     {} <- attemptWriteTaskShouldError (File.writeUtf8 (Path.fromStr "/System/asdf") "str") "PermissionDenied" |> Task.await

--- a/src/host.c
+++ b/src/host.c
@@ -1,8 +1,8 @@
 #include <stdint.h>
 
-extern uint32_t rust_main();
+extern int32_t rust_main();
 
 int main() {
-  uint32_t result = rust_main();
+  int32_t result = rust_main();
   return (int)result;
 }

--- a/src/main.roc
+++ b/src/main.roc
@@ -1,5 +1,5 @@
 platform "cli"
-    requires {} { main : Task {} U32 }
+    requires {} { main : Task {} I32 }
     exposes [
         Path,
         Arg,
@@ -24,5 +24,5 @@ platform "cli"
     imports [Task.{ Task }]
     provides [mainForHost]
 
-mainForHost : Task {} U32 as Fx
+mainForHost : Task {} I32 as Fx
 mainForHost = main


### PR DESCRIPTION
This PR was discussed in this [zulip thread](https://roc.zulipchat.com/#narrow/stream/231634-beginners/topic/Basic-cli.20main.20failure.20type/near/368480397), and updates main from `main : Task {} U32` to `main : Task {} I32` so that negative integer values can be returned by Roc apps.