### PR TITLE
workaround MODULE NOT IMPORTED error

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
           llvmPkgs.clang
           expect
           nmap
+          simple-http-server
         ]);
       in {
 

--- a/src/Task.roc
+++ b/src/Task.roc
@@ -124,7 +124,7 @@ await = \task, transform ->
         \result ->
             when result is
                 Ok a -> transform a |> InternalTask.toEffect
-                Err b -> Task.err b |> InternalTask.toEffect
+                Err b -> err b |> InternalTask.toEffect
 
     InternalTask.fromEffect effect
 
@@ -141,7 +141,7 @@ onErr = \task, transform ->
         (InternalTask.toEffect task)
         \result ->
             when result is
-                Ok a -> Task.ok a |> InternalTask.toEffect
+                Ok a -> ok a |> InternalTask.toEffect
                 Err b -> transform b |> InternalTask.toEffect
 
     InternalTask.fromEffect effect
@@ -159,8 +159,8 @@ map = \task, transform ->
         (InternalTask.toEffect task)
         \result ->
             when result is
-                Ok a -> Task.ok (transform a) |> InternalTask.toEffect
-                Err b -> Task.err b |> InternalTask.toEffect
+                Ok a -> ok (transform a) |> InternalTask.toEffect
+                Err b -> err b |> InternalTask.toEffect
 
     InternalTask.fromEffect effect
 
@@ -177,8 +177,8 @@ mapErr = \task, transform ->
         (InternalTask.toEffect task)
         \result ->
             when result is
-                Ok c -> Task.ok c |> InternalTask.toEffect
-                Err a -> Task.err (transform a) |> InternalTask.toEffect
+                Ok c -> ok c |> InternalTask.toEffect
+                Err a -> err (transform a) |> InternalTask.toEffect
 
     InternalTask.fromEffect effect
 
@@ -186,8 +186,8 @@ mapErr = \task, transform ->
 fromResult : Result a b -> Task a b
 fromResult = \result ->
     when result is
-        Ok a -> Task.ok a
-        Err b -> Task.err b
+        Ok a -> ok a
+        Err b -> err b
 
 ## Apply a task to another task applicatively. This can be used with
 ## [ok] to build a [Task] that returns a record.


### PR DESCRIPTION
This error only happens in some cases, not sure why:

```
❯ ./target/release/roc examples/helloWorld.roc 
Downloading https://github.com/roc-lang/basic-cli/releases/download/0.4.0-rc1/XLXhHBQi4g0rf22b7NCFMTZGBDgvdibf_JdaipvMnNg.tar.br
    into /home/username/.cache/roc/packages


── MODULE NOT IMPORTED ─ ...XhHBQi4g0rf22b7NCFMTZGBDgvdibf_JdaipvMnNg/Task.roc ─

The `Task` module is not imported:

127│                  Err b -> Task.err b |> InternalTask.toEffect
                               ^^^^^^^^

Did you mean to import it?


── MODULE NOT IMPORTED ─ ...XhHBQi4g0rf22b7NCFMTZGBDgvdibf_JdaipvMnNg/Task.roc ─

The `Task` module is not imported:

144│                  Ok a -> Task.ok a |> InternalTask.toEffect
                              ^^^^^^^

Did you mean to import it?


── MODULE NOT IMPORTED ─ ...XhHBQi4g0rf22b7NCFMTZGBDgvdibf_JdaipvMnNg/Task.roc ─

The `Task` module is not imported:

162│                  Ok a -> Task.ok (transform a) |> InternalTask.toEffect
                              ^^^^^^^

Did you mean to import it?


── MODULE NOT IMPORTED ─ ...XhHBQi4g0rf22b7NCFMTZGBDgvdibf_JdaipvMnNg/Task.roc ─

The `Task` module is not imported:

163│                  Err b -> Task.err b |> InternalTask.toEffect
                               ^^^^^^^^

Did you mean to import it?


── MODULE NOT IMPORTED ─ ...XhHBQi4g0rf22b7NCFMTZGBDgvdibf_JdaipvMnNg/Task.roc ─

The `Task` module is not imported:

180│                  Ok c -> Task.ok c |> InternalTask.toEffect
                              ^^^^^^^

Did you mean to import it?


── MODULE NOT IMPORTED ─ ...XhHBQi4g0rf22b7NCFMTZGBDgvdibf_JdaipvMnNg/Task.roc ─

The `Task` module is not imported:

181│                  Err a -> Task.err (transform a) |> InternalTask.toEffect
                               ^^^^^^^^

Did you mean to import it?


── MODULE NOT IMPORTED ─ ...XhHBQi4g0rf22b7NCFMTZGBDgvdibf_JdaipvMnNg/Task.roc ─

The `Task` module is not imported:

189│          Ok a -> Task.ok a
                      ^^^^^^^

Did you mean to import it?


── MODULE NOT IMPORTED ─ ...XhHBQi4g0rf22b7NCFMTZGBDgvdibf_JdaipvMnNg/Task.roc ─

The `Task` module is not imported:

190│          Err b -> Task.err b
                       ^^^^^^^^

Did you mean to import it?

────────────────────────────────────────────────────────────────────────────────

8 errors and 0 warnings found in 5866 ms.

You can run the program anyway with roc run examples/helloWorld.roc

```