### PR TITLE
Stop using "rlib"

### DIFF
--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -15,7 +15,7 @@ codegen-units = 1
 [lib]
 name = "host"
 path = "src/lib.rs"
-crate-type = ["staticlib", "rlib"]
+crate-type = ["staticlib", "lib"]
 
 [[bin]]
 name = "host"


### PR DESCRIPTION
I don't know if this matters at all, but I don't think we should use "rlib". The [rust docs](https://doc.rust-lang.org/reference/linkage.html) suggest using "lib" by default. "lib" probably just aliases to "rlib", but it lets the compiler pick what it wants.