### PR TITLE
Use `|> Num.toNat` in advance of Str dropping Nat

### DIFF
--- a/platform/Path.roc
+++ b/platform/Path.roc
@@ -309,7 +309,7 @@ withExtension = \path, extension ->
                     Err NotFound -> bytes
 
             beforeDot
-            |> List.reserve (1 + Str.countUtf8Bytes extension)
+            |> List.reserve (1 + (Str.countUtf8Bytes extension |> Num.toNat))
             |> List.append (Num.toU8 '.')
             |> List.concat (Str.toUtf8 extension)
             |> ArbitraryBytes
@@ -322,7 +322,7 @@ withExtension = \path, extension ->
                     Err NotFound -> str
 
             beforeDot
-            |> Str.reserve (1 + Str.countUtf8Bytes extension)
+            |> Str.reserve (1 + (Str.countUtf8Bytes extension |> Num.toNat))
             |> Str.concat "."
             |> Str.concat extension
             |> FromStr


### PR DESCRIPTION
Needed to get tests passing in https://github.com/roc-lang/roc/pull/6396

(Once `List` has dropped `Nat` too, this can be reverted.)