### PR TITLE
Remove remaining `Nat` uses from basic-cli

### DIFF
--- a/platform/Arg.roc
+++ b/platform/Arg.roc
@@ -59,7 +59,7 @@ Parser a := [
 ]
 
 # Indices in an arguments list that have already been parsed.
-Taken : Set Nat
+Taken : Set U64
 
 # A representation of parsed and unparsed arguments in a constant list of
 # command-line arguments.
@@ -179,7 +179,7 @@ findOneArg = \long, short, { args, taken } ->
         Err NotFound
     else
         # Return the next argument after the given one
-        List.get args (argIndex + 1)
+        List.get args (1 + argIndex |> Num.intCast)
         |> Result.mapErr (\_ -> NotFound)
         |> Result.map
             (\val ->
@@ -445,13 +445,13 @@ parseHelp = \@Parser parser, args ->
         WithConfig parser2 _config ->
             parseHelp parser2 args
 
-nextUnmarked : MarkedArgs -> Result { index : Nat, val : Str } [OutOfBounds]
+nextUnmarked : MarkedArgs -> Result { index : U64, val : Str } [OutOfBounds]
 nextUnmarked = \marked ->
     help = \index ->
         if Set.contains marked.taken index then
             help (index + 1)
         else
-            List.get marked.args index
+            List.get marked.args (Num.intCast index)
             |> Result.map \val -> { index, val }
 
     help 0
@@ -539,10 +539,10 @@ parseFormatted = \@NamedParser parser, args ->
         \e ->
             Str.concat (Str.concat (formatHelp (@NamedParser parser)) "\n\n") (formatError e)
 
-indent : Nat -> Str
-indent = \n -> Str.repeat " " n
+indent : U64 -> Str
+indent = \n -> Str.repeat " " (Num.intCast n)
 
-indentLevel : Nat
+indentLevel : U64
 indentLevel = 4
 
 mapNonEmptyStr = \s, f -> if Str.isEmpty s then s else f s
@@ -568,7 +568,7 @@ formatHelp = \@NamedParser { name, help, parser } ->
     \(fmtCmdHelp)
     """
 
-# formatHelpHelp : Nat, Help -> Str
+# formatHelpHelp : U64, Help -> Str
 formatHelpHelp = \n, cmdHelp ->
     indented = indent n
 
@@ -641,7 +641,7 @@ formatSubCommand = \n, { name, help } ->
 
     "\(indented)\(name)\(fmtHelp)"
 
-formatOptionConfig : Nat, OptionConfig -> Str
+formatOptionConfig : U64, OptionConfig -> Str
 formatOptionConfig = \n, { long, short, help, type } ->
     indented = indent n
 
@@ -655,7 +655,7 @@ formatOptionConfig = \n, { long, short, help, type } ->
 
     "\(indented)--\(long)\(formattedShort)\(formattedHelp)  (\(formattedType))"
 
-formatPositionalConfig : Nat, PositionalConfig -> Str
+formatPositionalConfig : U64, PositionalConfig -> Str
 formatPositionalConfig = \n, { name, help } ->
     indented = indent n
 

--- a/platform/Effect.roc
+++ b/platform/Effect.roc
@@ -81,12 +81,12 @@ sendRequest : Box Request -> Effect Response
 
 tcpConnect : Str, U16 -> Effect InternalTcp.ConnectResult
 tcpClose : InternalTcp.Stream -> Effect {}
-tcpReadUpTo : Nat, InternalTcp.Stream -> Effect InternalTcp.ReadResult
-tcpReadExactly : Nat, InternalTcp.Stream -> Effect InternalTcp.ReadExactlyResult
+tcpReadUpTo : U64, InternalTcp.Stream -> Effect InternalTcp.ReadResult
+tcpReadExactly : U64, InternalTcp.Stream -> Effect InternalTcp.ReadExactlyResult
 tcpReadUntil : U8, InternalTcp.Stream -> Effect InternalTcp.ReadResult
 tcpWrite : List U8, InternalTcp.Stream -> Effect InternalTcp.WriteResult
 
-pathType: List U8 -> Effect (Result InternalPath.InternalPathType InternalPath.GetMetadataErr)
+pathType : List U8 -> Effect (Result InternalPath.InternalPathType InternalPath.GetMetadataErr)
 
 posixTime : Effect U128
 sleepMillis : U64 -> Effect {}

--- a/platform/InternalTcp.roc
+++ b/platform/InternalTcp.roc
@@ -13,7 +13,7 @@ interface InternalTcp
     ]
     imports []
 
-Stream := Nat
+Stream := U64
 
 ConnectErr : [
     PermissionDenied,

--- a/platform/Path.roc
+++ b/platform/Path.roc
@@ -360,7 +360,7 @@ withExtension = \path, extension ->
                     Err NotFound -> bytes
 
             beforeDot
-            |> List.reserve (1 + (Str.countUtf8Bytes extension |> Num.toNat))
+            |> List.reserve (Str.countUtf8Bytes extension |> Num.intCast |> Num.addSaturated 1)
             |> List.append (Num.toU8 '.')
             |> List.concat (Str.toUtf8 extension)
             |> ArbitraryBytes
@@ -373,7 +373,7 @@ withExtension = \path, extension ->
                     Err NotFound -> str
 
             beforeDot
-            |> Str.reserve (1 + (Str.countUtf8Bytes extension |> Num.toNat))
+            |> Str.reserve (Str.countUtf8Bytes extension |> Num.addSaturated 1)
             |> Str.concat "."
             |> Str.concat extension
             |> FromStr

--- a/platform/Tcp.roc
+++ b/platform/Tcp.roc
@@ -78,7 +78,7 @@ close = \stream ->
 ## ```
 ##
 ## > To read an exact number of bytes or fail, you can use [Tcp.readExactly] instead.
-readUpTo : Nat, Stream -> Task (List U8) [TcpReadErr StreamErr]
+readUpTo : U64, Stream -> Task (List U8) [TcpReadErr StreamErr]
 readUpTo = \bytesToRead, stream ->
     Effect.tcpReadUpTo bytesToRead stream
     |> Effect.map InternalTcp.fromReadResult
@@ -93,7 +93,7 @@ readUpTo = \bytesToRead, stream ->
 ##
 ## `TcpUnexpectedEOF` is returned if the stream ends before the specfied number of bytes is reached.
 ##
-readExactly : Nat, Stream -> Task (List U8) [TcpReadErr StreamErr, TcpUnexpectedEOF]
+readExactly : U64, Stream -> Task (List U8) [TcpReadErr StreamErr, TcpUnexpectedEOF]
 readExactly = \bytesToRead, stream ->
     Effect.tcpReadExactly bytesToRead stream
     |> Effect.map

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -3,8 +3,8 @@
 mod command_glue;
 mod dir_glue;
 mod file_glue;
-mod path_glue;
 mod glue;
+mod path_glue;
 mod tcp_glue;
 
 use core::alloc::Layout;
@@ -355,7 +355,8 @@ pub extern "C" fn roc_fx_exePath(_roc_str: &RocStr) -> RocResult<RocList<u8>, ()
 }
 
 #[no_mangle]
-pub extern "C" fn roc_fx_stdinLine() -> RocResult<RocStr, ()> { // () is used for EOF
+pub extern "C" fn roc_fx_stdinLine() -> RocResult<RocStr, ()> {
+    // () is used for EOF
     let stdin = std::io::stdin();
 
     match stdin.lock().lines().next() {
@@ -459,7 +460,11 @@ pub extern "C" fn roc_fx_pathType(
 ) -> RocResult<path_glue::InternalPathType, path_glue::GetMetadataErr> {
     let path = path_from_roc_path(roc_path);
     match path.symlink_metadata() {
-        Ok(m) => { RocResult::ok(path_glue::InternalPathType { isDir: m.is_dir(), isFile: m.is_file(), isSymLink: m.is_symlink() }) }
+        Ok(m) => RocResult::ok(path_glue::InternalPathType {
+            isDir: m.is_dir(),
+            isFile: m.is_file(),
+            isSymLink: m.is_symlink(),
+        }),
         Err(err) => RocResult::err(toRocGetMetadataError(err)),
     }
 }

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -772,12 +772,12 @@ pub extern "C" fn roc_fx_tcpClose(stream_ptr: *mut BufReader<TcpStream>) {
 
 #[no_mangle]
 pub extern "C" fn roc_fx_tcpReadUpTo(
-    bytes_to_read: usize,
+    bytes_to_read: u64,
     stream_ptr: *mut BufReader<TcpStream>,
 ) -> tcp_glue::ReadResult {
     let reader = unsafe { &mut *stream_ptr };
 
-    let mut chunk = reader.take(bytes_to_read as u64);
+    let mut chunk = reader.take(bytes_to_read);
 
     match chunk.fill_buf() {
         Ok(received) => {
@@ -794,17 +794,16 @@ pub extern "C" fn roc_fx_tcpReadUpTo(
 
 #[no_mangle]
 pub extern "C" fn roc_fx_tcpReadExactly(
-    bytes_to_read: usize,
+    bytes_to_read: u64,
     stream_ptr: *mut BufReader<TcpStream>,
 ) -> tcp_glue::ReadExactlyResult {
     let reader = unsafe { &mut *stream_ptr };
-
-    let mut buffer = Vec::with_capacity(bytes_to_read);
+    let mut buffer = Vec::with_capacity(bytes_to_read as usize);
     let mut chunk = reader.take(bytes_to_read as u64);
 
     match chunk.read_to_end(&mut buffer) {
         Ok(read) => {
-            if read < bytes_to_read {
+            if (read as u64) < bytes_to_read {
                 tcp_glue::ReadExactlyResult::UnexpectedEOF
             } else {
                 let rocList = RocList::from(&buffer[..]);


### PR DESCRIPTION
The `Num.intCast` calls can go away in the future, but they make the transition smoother because they should work with both today's version as well as a future version where `Nat` is gone!