### PR TITLE
Fix Task.roc

### DIFF
--- a/platform/Task.roc
+++ b/platform/Task.roc
@@ -224,10 +224,10 @@ batch = \current -> \next ->
 ##
 seq : List (Task ok err) -> Task (List ok) err
 seq = \tasks ->
-    List.walk tasks (Task.ok []) \state, task ->
-        value <- task |> Task.await
+    List.walk tasks (InternalTask.ok []) \state, task ->
+        value <- task |> await
 
-        state |> Task.map \values -> List.append values value
+        state |> map \values -> List.append values value
 
 ## Apply a task repeatedly for each item in a list
 ##
@@ -241,5 +241,5 @@ seq = \tasks ->
 ##
 forEach : List a, (a -> Task {} b) -> Task {} b
 forEach = \items, fn ->
-    List.walk items (Task.ok {}) \state, item ->
-        state |> Task.await \_ -> fn item
+    List.walk items (InternalTask.ok {}) \state, item ->
+        state |> await \_ -> fn item


### PR DESCRIPTION
I'm not sure why these are no longer allowed. Can diagnose later, but for now I just want to unblock `Nat` removal.