### PR TITLE
Update docs for `Task.seq`

### DIFF
--- a/platform/Task.roc
+++ b/platform/Task.roc
@@ -212,14 +212,14 @@ batch = \current -> \next ->
 
         map current f
 
-## Apply a task repeatedly to a list of items, and return a list of the resulting values
+## Apply each task in a list sequentially, and return a list of the resulting values.
+## Each task will be awaited before beginning the next task.
 ##
 ## ```
-## authors : List ID
-## getAuthor : ID -> Task Author [DbError]
+## fetchAuthorTasks List (Task Author [DbError])
 ##
 ## getAuthors : Task (List Author) [DbError]
-## getAuthors = Task.list authors getAuthor
+## getAuthors = Task.seq authorTasks 
 ## ```
 ##
 seq : List (Task ok err) -> Task (List ok) err

--- a/platform/Task.roc
+++ b/platform/Task.roc
@@ -216,10 +216,10 @@ batch = \current -> \next ->
 ## Each task will be awaited before beginning the next task.
 ##
 ## ```
-## fetchAuthorTasks List (Task Author [DbError])
+## fetchAuthorTasks : List (Task Author [DbError])
 ##
 ## getAuthors : Task (List Author) [DbError]
-## getAuthors = Task.seq authorTasks 
+## getAuthors = Task.seq fetchAuthorTasks 
 ## ```
 ##
 seq : List (Task ok err) -> Task (List ok) err


### PR DESCRIPTION
Changes the docs for `Task.seq` to match the current correct name and usage. I noticed when fiddling with the tutorial that the docs seemed to have gotten out-of-sync with the implementation recently.

Hopefully the new example is correct and clear, I'm quite new to the language!