### PR TITLE
 EnvDecoding type matches changes to decoding from here: https://github.com/roc-lang/roc/pull/6587

### DIFF
--- a/platform/EnvDecoding.roc
+++ b/platform/EnvDecoding.roc
@@ -98,6 +98,6 @@ envRecord = \_initialState, _stepField, _finalizer -> Decode.custom \bytes, @Env
 # TODO: we must currently annotate the arrows here so that the lambda sets are
 # exercised, and the solver can find an ambient lambda set for the
 # specialization.
-envTuple : _, (_, _ -> [Next (Decoder _ _), TooLong]), (_ -> _) -> Decoder _ _
+envTuple : _, (_, _ -> [Next (Decoder _ _), TooLong]), (_, _ -> _) -> Decoder _ _
 envTuple = \_initialState, _stepElem, _finalizer -> Decode.custom \bytes, @EnvFormat {} ->
         { result: Err TooShort, rest: bytes }


### PR DESCRIPTION
This PR for optional record field decoding changes the type of the finalize function to take two args:
 https://github.com/roc-lang/roc/pull/6587
 This updates this to 