### PR TITLE
Adjust setting content-type header to avoid conflicts

### DIFF
--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -612,16 +612,22 @@ pub extern "C" fn roc_fx_sendRequest(roc_request: &roc_app::Request) -> roc_app:
     let mut req_builder = hyper::Request::builder()
         .method(method)
         .uri(roc_request.url.as_str());
+    let mut has_content_type_header = false;
 
     for header in roc_request.headers.iter() {
         let (name, value) = header.as_Header();
         req_builder = req_builder.header(name.as_str(), value.as_str());
+        if name.eq_ignore_ascii_case("Content-Type") {
+            has_content_type_header = true;
+        }
     }
 
-    let mime_type_str = roc_request.mimeType.as_str();
     let bytes = String::from_utf8(roc_request.body.as_slice().to_vec()).unwrap();
+    let mime_type_str = roc_request.mimeType.as_str();
 
-    req_builder = req_builder.header("Content-Type", mime_type_str);
+    if !has_content_type_header && mime_type_str.len() > 0 {
+        req_builder = req_builder.header("Content-Type", mime_type_str);
+    }
 
     let request = match req_builder.body(bytes) {
         Ok(req) => req,


### PR DESCRIPTION
Hi!
As mentioned in [this](https://roc.zulipchat.com/#narrow/stream/316715-contributing/topic/Http.20mimetype.2Fheaders.20combination/near/432427740) thread on zulip I've ran into an interesting problem while working on my first Roc program.

Basically, since `Http.defaultRequest` has a `mimeType` set to empty string as a default, it's always inserted into HTTP headers. Now, this becomes a problem as soon as I add "Content-Type" header manually, which was the first thing I tried when working on my code, for example:
```rust
        { Http.defaultRequest &
            url: "https://foo.com",
            method: Post,
            body,
            headers: [Http.header "Content-Type" "application/json"],
        }
```
Rust-side, this would end up in request looking like so:

```
Builder { inner: Ok(Parts { method: POST, uri: https://invoice-generator.com/, version: HTTP/1.1, headers: {"content-type": "application-json", "content-type": ""} }) }
```
and this actually broke requests I was making to the API (it wasn't getting correct content-type). Same case, when there's both mimeType and headers, eg
```rust
        { Http.defaultRequest &
            url: "https://foo.com",
            method: Post,
            body,
            headers: [Http.header "Content-Type" "application/json"],
            mimeType: "application/json"
        }
```
this doesn't work either, because content-type is inserted into headers twice.


What my change achieves is:
1. Don't apply content-type header at all, if the mimeType is empty string.
2. Make sure that if there's a header with content-type, it takes precedence.

I hope that makes sense and is a useful contribution! I've spent quite some time figuring out why my requests weren't working :smile: 
