### PR TITLE
Add `Task.result`

### DIFF
--- a/ci/expect_scripts/result.exp
+++ b/ci/expect_scripts/result.exp
@@ -1,0 +1,15 @@
+#!/usr/bin/expect
+
+# uncomment line below for debugging
+# exp_internal 1
+
+set timeout 7
+
+spawn $env(EXAMPLES_DIR)result
+
+expect -exact "GOOD\r\n" {
+    exit 0
+}
+
+puts stderr "\nError: output was different from expected value."
+exit 1

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -19,3 +19,4 @@ stdin
 tcp-client
 time
 task-list
+result

--- a/examples/result.roc
+++ b/examples/result.roc
@@ -3,6 +3,10 @@ app "result"
     imports [pf.Stdout, pf.Task.{ Task }]
     provides [main] to pf
 
+# This example demonstrates the use of `Task.result`.
+# It transforms a task that can either succeed with `ok`, or fail with `err`, into
+# a task that succeeds with `Result ok err`.
+
 main : Task {} I32
 main =
     when checkFile "good" |> Task.result! is

--- a/examples/result.roc
+++ b/examples/result.roc
@@ -1,0 +1,20 @@
+app "result"
+    packages { pf: "../platform/main.roc" }
+    imports [pf.Stdout, pf.Task.{ Task }]
+    provides [main] to pf
+
+main : Task {} I32
+main =
+    when checkFile "good" |> Task.result! is
+        Ok Good -> Stdout.line "GOOD"
+        Ok Bad -> Stdout.line "BAD"
+        Err IOError -> Stdout.line "IOError"
+
+checkFile : Str -> Task [Good, Bad] [IOError]
+checkFile = \str ->
+    if str == "good" then 
+        Task.ok Good 
+    else if str == "bad" then 
+        Task.ok Bad 
+    else 
+        Task.err IOError

--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1713180354,
-        "narHash": "sha256-laLEu12yP0gD+dqqT3OClH6LLD1uAtPiyto0y5D7xus=",
+        "lastModified": 1713751891,
+        "narHash": "sha256-IuCUqK6N5P/uClhmAM/Z+JNNvrTpSSe6nkC7dxXMikI=",
         "owner": "roc-lang",
         "repo": "roc",
-        "rev": "a0cf09f9802eb07a05a73155729e370ebf3a9e9a",
+        "rev": "e4713ce2c5c07619e39e59fbfde29e9021cd78d1",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712628742,
-        "narHash": "sha256-FIAlt8mbPUs8jRuh6xpFtYzDsyHzmiLNPcen8HwvD00=",
+        "lastModified": 1713752081,
+        "narHash": "sha256-x0QDETp7paa8qq+LX6191JwSq8abUFXCnKNulQ8L7ps=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e7354bb9e5f68b2074e272fd5f5ac3f4848860ba",
+        "rev": "606c0ecb23c676c444a0b026eecf800d5bd5fec2",
         "type": "github"
       },
       "original": {

--- a/platform/Task.roc
+++ b/platform/Task.roc
@@ -248,7 +248,7 @@ forEach = \items, fn ->
 ## Transform a task that can either succeed with `ok`, or fail with `err`, into
 ## a task that succeeds with `Result ok err`.
 ##
-## This is useful when chaining tasks using the `!` suffix. For example
+## This is useful when chaining tasks using the `!` suffix. For example:
 ##
 ## ```
 ## # Path.roc

--- a/platform/Task.roc
+++ b/platform/Task.roc
@@ -14,7 +14,7 @@ interface Task
         batch,
         seq,
         forEach,
-        toResult,
+        result,
     ]
     imports [Effect, InternalTask]
 
@@ -48,7 +48,7 @@ loop = \state, step ->
             \res ->
                 when res is
                     Ok (Step newState) -> Step newState
-                    Ok (Done result) -> Done (Ok result)
+                    Ok (Done newResult) -> Done (Ok newResult)
                     Err e -> Done (Err e)
 
     Effect.loop state looper
@@ -103,8 +103,8 @@ attempt : Task a b, (Result a b -> Task c d) -> Task c d
 attempt = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
-        \result ->
-            when result is
+        \res ->
+            when res is
                 Ok a -> transform (Ok a) |> InternalTask.toEffect
                 Err b -> transform (Err b) |> InternalTask.toEffect
 
@@ -125,8 +125,8 @@ await : Task a b, (a -> Task c b) -> Task c b
 await = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
-        \result ->
-            when result is
+        \res ->
+            when res is
                 Ok a -> transform a |> InternalTask.toEffect
                 Err b -> err b |> InternalTask.toEffect
 
@@ -143,8 +143,8 @@ onErr : Task a b, (b -> Task a c) -> Task a c
 onErr = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
-        \result ->
-            when result is
+        \res ->
+            when res is
                 Ok a -> ok a |> InternalTask.toEffect
                 Err b -> transform b |> InternalTask.toEffect
 
@@ -161,8 +161,8 @@ map : Task a c, (a -> b) -> Task b c
 map = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
-        \result ->
-            when result is
+        \res ->
+            when res is
                 Ok a -> ok (transform a) |> InternalTask.toEffect
                 Err b -> err b |> InternalTask.toEffect
 
@@ -179,8 +179,8 @@ mapErr : Task c a, (a -> b) -> Task c b
 mapErr = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
-        \result ->
-            when result is
+        \res ->
+            when res is
                 Ok c -> ok c |> InternalTask.toEffect
                 Err a -> err (transform a) |> InternalTask.toEffect
 
@@ -188,8 +188,8 @@ mapErr = \task, transform ->
 
 ## Use a Result among other Tasks by converting it into a [Task].
 fromResult : Result a b -> Task a b
-fromResult = \result ->
-    when result is
+fromResult = \res ->
+    when res is
         Ok a -> ok a
         Err b -> err b
 
@@ -245,31 +245,27 @@ forEach = \items, fn ->
     List.walk items (InternalTask.ok {}) \state, item ->
         state |> await \_ -> fn item
 
-## Transform a task that can succeed with `ok` or fail with `err` into a task
-## that always succeeds with a `Result ok err`.
+## Transform a task that can either succeed with `ok`, or fail with `err`, into
+## a task that succeeds with `Result ok err`.
 ##
-## This is useful when chaining tasks using the `!` suffix.
+## This is useful when chaining tasks using the `!` suffix. For example
 ##
 ## ```
 ## # Path.roc
 ## checkFile : Str -> Task [Good, Bad] [IOError]
 ##
 ## # main.roc
-## result =
-##     checkFile "/usr/local/bin/roc"
-##     |> Task.toResult!
-##
-## when result is
+## when checkFile "/usr/local/bin/roc" |> Task.result! is
 ##     Ok Good -> "..."
 ##     Ok Bad -> "..."
 ##     Err IOError -> "..."
 ## ```
 ##
-toResult : Task ok err -> Task (Result ok err) *
-toResult = \task ->
+result : Task ok err -> Task (Result ok err) *
+result = \task ->
     effect =
         Effect.after
             (InternalTask.toEffect task)
-            \result -> result |> ok |> InternalTask.toEffect
+            \res -> res |> ok |> InternalTask.toEffect
 
     InternalTask.fromEffect effect


### PR DESCRIPTION
[Zulip discussion](https://roc.zulipchat.com/#narrow/stream/304902-show-and-tell/topic/Initial.20Chaining.20Syntax/near/433559391)

## Test program

```roc 
app ""
    packages { pf: "../platform/main.roc" }
    imports [pf.Stdout, pf.Task.{ Task }]
    provides [main] to pf

main : Task {} I32
main =
    
    result =
        checkFile "bad"
        |> Task.result!

    when result is
        Ok Good -> Stdout.line "GOOD"
        Ok Bad -> Stdout.line "BAD"
        Err IOError -> Stdout.line "IOError"

checkFile : Str -> Task [Good, Bad] [IOError]
checkFile = \str ->
    if str == "good" then 
        Task.ok Good 
    else if str == "bad" then 
        Task.ok Bad 
    else 
        Task.err IOError
```