### PR TITLE
Remove unused `Effect` type import in `Path`

### DIFF
--- a/platform/Path.roc
+++ b/platform/Path.roc
@@ -15,7 +15,7 @@ interface Path
         isSymLink,
         type,
     ]
-    imports [InternalPath.{ InternalPath }, InternalPath.{ GetMetadataErr }, Effect.{ Effect }, InternalTask, Task.{ Task }]
+    imports [InternalPath.{ InternalPath }, InternalPath.{ GetMetadataErr }, Effect, InternalTask, Task.{ Task }]
 
 # You can canonicalize a [Path] using `Path.canonicalize`.
 #


### PR DESCRIPTION
`Path.roc` was importing `Effect.Effect` but it never used it directly. The version of the compiler on `main` doesn't catch this, but the one on `new-imports` does and it makes the tests fail.