### PR TITLE
Don't print a blank line if `Exit` is given ""

### DIFF
--- a/platform/main.roc
+++ b/platform/main.roc
@@ -33,7 +33,7 @@ mainForHost =
                 if Str.isEmpty str then
                     Task.err code
                 else
-                    Stderr.line str
+                    line str
                     |> Task.onErr \_ -> Task.err code
                     |> Task.await \{} -> Task.err code
 

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -20,7 +20,7 @@ platform "cli"
         Tty,
     ]
     packages {}
-    imports [Task.{ Task }, Stderr]
+    imports [Task.{ Task }, Stderr.{line}]
     provides [mainForHost]
 
 mainForHost : Task {} I32 as Fx
@@ -38,6 +38,6 @@ mainForHost =
                     |> Task.await \{} -> Task.err code
 
             Err err ->
-                Stderr.line "Program exited early with error: $(Inspect.toStr err)"
+                line "Program exited early with error: $(Inspect.toStr err)"
                 |> Task.onErr \_ -> Task.err 1
                 |> Task.await \_ -> Task.err 1


### PR DESCRIPTION
Also made it more explicit that it's `Stderr.line` and not `Stdout.line` at the call site