### PR TITLE
Add `Env.platform` effect

### DIFF
--- a/platform/Effect.roc
+++ b/platform/Effect.roc
@@ -41,6 +41,7 @@ hosted Effect
         sleepMillis,
         commandStatus,
         commandOutput,
+        currentArchOS,
     ]
     imports [
         InternalHttp.{ Request, InternalResponse },
@@ -98,3 +99,5 @@ dirCreate : List U8 -> Effect (Result {} Str)
 dirCreateAll : List U8 -> Effect (Result {} Str)
 dirDeleteEmpty : List U8 -> Effect (Result {} Str)
 dirDeleteAll : List U8 -> Effect (Result {} Str)
+
+currentArchOS : Effect {arch: Str, os: Str}

--- a/platform/Env.roc
+++ b/platform/Env.roc
@@ -131,8 +131,29 @@ dict =
 # if decoding into a tag union of [Present val, Missing], then it knows what to do.
 # decodeAll : Task val [] [EnvDecodingFailed Str] [Env] where val implements Decoding
 
-platform : Task {arch : Str, os: Str} *
+ARCH : [X86, X64, ARM, AARCH64, OTHER Str]
+OS : [LINUX, MACOS, WINDOWS, OTHER Str]
+
+platform : Task {arch : ARCH, os: OS} *
 platform =
     Effect.currentArchOS
-    |> Effect.map Ok
+    |> Effect.map \fromRust ->
+    
+        arch = 
+            when fromRust.arch is 
+                "x86" -> X86
+                "x86_64" -> X64
+                "arm" -> ARM
+                "aarch64" -> AARCH64
+                _ -> OTHER fromRust.arch
+
+        os = 
+            when fromRust.os is 
+                "linux" -> LINUX
+                "macos" -> MACOS
+                "windows" -> WINDOWS
+                _ -> OTHER fromRust.os
+
+        Ok {arch, os}
+
     |> InternalTask.fromEffect

--- a/platform/Env.roc
+++ b/platform/Env.roc
@@ -134,21 +134,28 @@ dict =
 ARCH : [X86, X64, ARM, AARCH64, OTHER Str]
 OS : [LINUX, MACOS, WINDOWS, OTHER Str]
 
+## Returns the current Achitecture and Operating System.
+##
+## `ARCH : [X86, X64, ARM, AARCH64, OTHER Str]`
+## `OS : [LINUX, MACOS, WINDOWS, OTHER Str]`
+##
+## Note these values are constants from when the platform is built.
+##
 platform : Task {arch : ARCH, os: OS} *
 platform =
     Effect.currentArchOS
     |> Effect.map \fromRust ->
-    
-        arch = 
-            when fromRust.arch is 
+
+        arch =
+            when fromRust.arch is
                 "x86" -> X86
                 "x86_64" -> X64
                 "arm" -> ARM
                 "aarch64" -> AARCH64
                 _ -> OTHER fromRust.arch
 
-        os = 
-            when fromRust.os is 
+        os =
+            when fromRust.os is
                 "linux" -> LINUX
                 "macos" -> MACOS
                 "windows" -> WINDOWS

--- a/platform/Env.roc
+++ b/platform/Env.roc
@@ -1,4 +1,4 @@
-module [cwd, dict, var, decode, exePath, setCwd]
+module [cwd, dict, var, decode, exePath, setCwd, platform]
 
 import Task exposing [Task]
 import Path exposing [Path]
@@ -130,3 +130,9 @@ dict =
 # Alternatively, it could make sense to have some sort of tag union convention here, e.g.
 # if decoding into a tag union of [Present val, Missing], then it knows what to do.
 # decodeAll : Task val [] [EnvDecodingFailed Str] [Env] where val implements Decoding
+
+platform : Task {arch : Str, os: Str} *
+platform =
+    Effect.currentArchOS
+    |> Effect.map Ok
+    |> InternalTask.fromEffect

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -1117,3 +1117,17 @@ fn handleDirError(io_err: std::io::Error) -> RocStr {
         _ => RocStr::from(RocStr::from(format!("{:?}", io_err).as_str())),
     }
 }
+
+#[repr(C)]
+pub struct ReturnArchOS {
+    arch: RocStr,
+    os: RocStr,
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_currentArchOS() -> ReturnArchOS {
+    ReturnArchOS {
+        arch: std::env::consts::ARCH.into(),
+        os: std::env::consts::OS.into(),
+    }
+}


### PR DESCRIPTION
This will be helpful for build scripts which can use this instead of shelling out to another program like `uname`.

```roc
# Env.roc
ARCH : [X86, X64, ARM, AARCH64, OTHER Str]
OS : [LINUX, MACOS, WINDOWS, OTHER Str]

platform : Task {arch : ARCH, os: OS} *
```

```roc 
app [main] { pf: platform "../platform/main.roc" }

import pf.Stdout
import pf.Task exposing [Task]
import pf.Env

main =
    platform = Env.platform!
    Stdout.line! "Running on $(Inspect.toStr platform)"
```
```sh
$ roc examples/test.roc
Running on {arch: AARCH64, os: MACOS}
```

Closes #203 