### PR TITLE
Update Arg module to new record builder syntax

### DIFF
--- a/examples/args.roc
+++ b/examples/args.roc
@@ -6,7 +6,7 @@ import pf.Stdout
 import pf.Stderr
 import pf.Task exposing [Task]
 import pf.Arg.Cli as Cli
-import pf.Arg.Subcommand as Subcommand
+import pf.Arg.SubCmd as SubCmd
 import pf.Arg.Opt as Opt
 import pf.Arg.Param as Param
 import pf.Arg
@@ -34,7 +34,7 @@ main =
             Task.err (Exit 1 "")
 
 cli =
-    Subcommand.required [maxSubcommand, divideSubcommand]
+    SubCmd.required [maxSubcommand, divideSubcommand]
     |> Cli.finish {
         name: "args-example",
         description: "A calculator example of the CLI platform argument parser.",
@@ -48,7 +48,7 @@ maxSubcommand =
         first: Param.dec { name: "first", help: "the first number to compare." },
         rest: Param.decList { name: "rest", help: "the other numbers to compare." },
     }
-    |> Subcommand.finish {
+    |> SubCmd.finish {
         name: "max",
         description: "Find the largest of multiple numbers.",
         mapper: Max,
@@ -67,7 +67,7 @@ divideSubcommand =
             help: "the number to divide by; corresponds to a denominator.",
         },
     }
-    |> Subcommand.finish {
+    |> SubCmd.finish {
         name: "div",
         description: "Divide two numbers.",
         mapper: Div,

--- a/examples/args.roc
+++ b/examples/args.roc
@@ -15,7 +15,7 @@ main =
     args = Arg.list! {}
 
     when Cli.parseOrDisplayMessage cli args is
-        Ok { command: subcommand } ->
+        Ok subcommand ->
             mathOutcome =
                 when subcommand is
                     Max { first, rest } ->
@@ -34,9 +34,7 @@ main =
             Task.err (Exit 1 "")
 
 cli =
-    Cli.build {
-        command: <- Subcommand.required [maxSubcommand, divideSubcommand],
-    }
+    Subcommand.required [maxSubcommand, divideSubcommand]
     |> Cli.finish {
         name: "args-example",
         description: "A calculator example of the CLI platform argument parser.",
@@ -45,10 +43,10 @@ cli =
     |> Cli.assertValid
 
 maxSubcommand =
-    Cli.build {
+    { Cli.combine <-
         # ensure there's at least one parameter provided
-        first: <- Param.dec { name: "first", help: "the first number to compare." },
-        rest: <- Param.decList { name: "rest", help: "the other numbers to compare." },
+        first: Param.dec { name: "first", help: "the first number to compare." },
+        rest: Param.decList { name: "rest", help: "the other numbers to compare." },
     }
     |> Subcommand.finish {
         name: "max",
@@ -57,19 +55,17 @@ maxSubcommand =
     }
 
 divideSubcommand =
-    Cli.build {
-        dividend: <-
-            Opt.dec {
-                short: "n",
-                long: "dividend",
-                help: "the number to divide; corresponds to a numerator.",
-            },
-        divisor: <-
-            Opt.dec {
-                short: "d",
-                long: "divisor",
-                help: "the number to divide by; corresponds to a denominator.",
-            },
+    { Cli.combine <-
+        dividend: Opt.dec {
+            short: "n",
+            long: "dividend",
+            help: "the number to divide; corresponds to a numerator.",
+        },
+        divisor: Opt.dec {
+            short: "d",
+            long: "divisor",
+            help: "the number to divide by; corresponds to a denominator.",
+        },
     }
     |> Subcommand.finish {
         name: "div",

--- a/examples/record-builder.roc
+++ b/examples/record-builder.roc
@@ -7,9 +7,9 @@ import pf.Task exposing [Task]
 
 main =
     myrecord : Task { apples : List Str, oranges : List Str } []_
-    myrecord = Task.ok {
-        apples: <- getFruit Apples |> Task.batch,
-        oranges: <- getFruit Oranges |> Task.batch,
+    myrecord = { sequenceTasks <-
+        apples: getFruit Apples,
+        oranges: getFruit Oranges,
     }
 
     { apples, oranges } = myrecord!
@@ -26,3 +26,10 @@ getFruit = \request ->
     when request is
         Apples -> Task.ok ["Granny Smith", "Pink Lady", "Golden Delicious"]
         Oranges -> Task.ok ["Navel", "Blood Orange", "Clementine"]
+
+sequenceTasks : Task a err, Task b err, (a, b -> c) -> Task c err
+sequenceTasks = \firstTask, secondTask, mapper ->
+    first = firstTask!
+    second = secondTask!
+
+    Task.ok (mapper first second)

--- a/platform/Arg.roc
+++ b/platform/Arg.roc
@@ -32,8 +32,9 @@ list = \_ ->
 ##
 ## ```roc
 ## exampleCli =
-##     Cli.build {
-##         verbosity: <- Opt.count { short: "v", help: "How verbose our logs should be." },
+##     { Cli.combine <-
+##         verbosity: Opt.count { short: "v", help: "How verbose our logs should be." },
+##         alpha: Opt.mapbeU64 { short: "a", help: "Set the alpha level." },
 ##     }
 ##     |> Cli.finish {
 ##         name: "example",
@@ -56,6 +57,7 @@ list = \_ ->
 ##
 ##         Options:
 ##           -v             How verbose our logs should be.
+##           -a             Set the alpha level.
 ##           -h, --help     Show this help page.
 ##           -V, --version  Show the version.
 ##         """
@@ -90,7 +92,6 @@ parse = \parser ->
         ShowHelp { subcommandPath } ->
             helpMessage =
                 helpText parser.config subcommandPath parser.textStyle
-
             Stdout.line! helpMessage
             Task.err (Exit 0 "")
 
@@ -105,6 +106,5 @@ parse = \parser ->
 
                 $(usageHelp parser.config subcommandPath parser.textStyle)
                 """
-
             Stdout.line! incorrectUsageMessage
             Task.err (Exit 1 "")

--- a/platform/Arg/Builder.roc
+++ b/platform/Arg/Builder.roc
@@ -3,12 +3,15 @@ module [
     GetParamsAction,
     StopCollectingAction,
     CliBuilder,
-    fromState,
-    addOptions,
-    addParameters,
+    fromArgParser,
+    fromFullParser,
+    addOption,
+    addParameter,
     addSubcommands,
     updateParser,
     bindParser,
+    map,
+    combine,
     intoParts,
     checkForHelpAndVersion,
 ]
@@ -18,6 +21,7 @@ import Arg.Base exposing [
     ArgParserState,
     ArgParserResult,
     onSuccessfulArgParse,
+    mapSuccessfullyParsed,
     ArgExtractErr,
     OptionConfig,
     helpOption,
@@ -31,35 +35,49 @@ GetOptionsAction : { getOptions : {} }
 GetParamsAction : { getParams : {} }
 StopCollectingAction : []
 
-CliBuilder state action := {
-    parser : ArgParser state,
+CliBuilder data fromAction toAction := {
+    parser : ArgParser data,
     options : List OptionConfig,
     parameters : List ParameterConfig,
     subcommands : Dict Str SubcommandConfig,
 }
 
-fromState : base -> CliBuilder base GetOptionsAction
-fromState = \base ->
+fromArgParser : (List Arg -> Result { data : data, remainingArgs : List Arg } ArgExtractErr) -> CliBuilder data fromAction toAction
+fromArgParser = \parser ->
+    newParser = \{ args, subcommandPath } ->
+        when parser args is
+            Ok { data, remainingArgs } -> SuccessfullyParsed { data, remainingArgs, subcommandPath }
+            Err err -> IncorrectUsage err { subcommandPath }
+
     @CliBuilder {
-        parser: \{ args, subcommandPath } -> SuccessfullyParsed { data: base, remainingArgs: args, subcommandPath },
+        parser: newParser,
         options: [],
         parameters: [],
         subcommands: Dict.empty {},
     }
 
-addOptions : CliBuilder state action, List OptionConfig -> CliBuilder state action
-addOptions = \@CliBuilder builder, newOptions ->
-    @CliBuilder { builder & options: List.concat builder.options newOptions }
+fromFullParser : ArgParser data -> CliBuilder data fromAction toAction
+fromFullParser = \parser ->
+    @CliBuilder {
+        parser,
+        options: [],
+        parameters: [],
+        subcommands: Dict.empty {},
+    }
 
-addParameters : CliBuilder state action, List ParameterConfig -> CliBuilder state action
-addParameters = \@CliBuilder builder, newParameters ->
-    @CliBuilder { builder & parameters: List.concat builder.parameters newParameters }
+addOption : CliBuilder state fromAction toAction, OptionConfig -> CliBuilder state fromAction toAction
+addOption = \@CliBuilder builder, newOption ->
+    @CliBuilder { builder & options: List.append builder.options newOption }
 
-addSubcommands : CliBuilder state action, Dict Str SubcommandConfig -> CliBuilder state action
+addParameter : CliBuilder state fromAction toAction, ParameterConfig -> CliBuilder state fromAction toAction
+addParameter = \@CliBuilder builder, newParameter ->
+    @CliBuilder { builder & parameters: List.append builder.parameters newParameter }
+
+addSubcommands : CliBuilder state fromAction toAction, Dict Str SubcommandConfig -> CliBuilder state fromAction toAction
 addSubcommands = \@CliBuilder builder, newSubcommands ->
     @CliBuilder { builder & subcommands: Dict.insertAll builder.subcommands newSubcommands }
 
-setParser : CliBuilder state action, ArgParser nextState -> CliBuilder nextState nextAction
+setParser : CliBuilder state fromAction toAction, ArgParser nextState -> CliBuilder nextState fromAction toAction
 setParser = \@CliBuilder builder, parser ->
     @CliBuilder {
         options: builder.options,
@@ -68,7 +86,7 @@ setParser = \@CliBuilder builder, parser ->
         parser,
     }
 
-updateParser : CliBuilder state action, ({ data : state, remainingArgs : List Arg } -> Result { data : nextState, remainingArgs : List Arg } ArgExtractErr) -> CliBuilder nextState nextAction
+updateParser : CliBuilder state fromAction toAction, ({ data : state, remainingArgs : List Arg } -> Result { data : nextState, remainingArgs : List Arg } ArgExtractErr) -> CliBuilder nextState fromAction toAction
 updateParser = \@CliBuilder builder, updater ->
     newParser =
         { data, remainingArgs, subcommandPath } <- onSuccessfulArgParse builder.parser
@@ -79,7 +97,7 @@ updateParser = \@CliBuilder builder, updater ->
 
     setParser (@CliBuilder builder) newParser
 
-bindParser : CliBuilder state action, (ArgParserState state -> ArgParserResult (ArgParserState nextState)) -> CliBuilder nextState nextAction
+bindParser : CliBuilder state fromAction toAction, (ArgParserState state -> ArgParserResult (ArgParserState nextState)) -> CliBuilder nextState fromAction toAction
 bindParser = \@CliBuilder builder, updater ->
     newParser : ArgParser nextState
     newParser =
@@ -89,7 +107,7 @@ bindParser = \@CliBuilder builder, updater ->
     setParser (@CliBuilder builder) newParser
 
 intoParts :
-    CliBuilder state action
+    CliBuilder state fromAction toAction
     -> {
         parser : ArgParser state,
         options : List OptionConfig,
@@ -97,6 +115,42 @@ intoParts :
         subcommands : Dict Str SubcommandConfig,
     }
 intoParts = \@CliBuilder builder -> builder
+
+map : CliBuilder a fromAction toAction, (a -> b) -> CliBuilder b fromAction toAction
+map = \@CliBuilder builder, mapper ->
+    combinedParser = \input ->
+        builder.parser input
+        |> mapSuccessfullyParsed \{ data, remainingArgs, subcommandPath } ->
+            { data: mapper data, remainingArgs, subcommandPath }
+
+    @CliBuilder {
+        parser: combinedParser,
+        options: builder.options,
+        parameters: builder.parameters,
+        subcommands: builder.subcommands,
+    }
+
+combine : CliBuilder a action1 action2, CliBuilder b action2 action3, (a, b -> c) -> CliBuilder c action1 action3
+combine = \@CliBuilder left, @CliBuilder right, combiner ->
+    combinedParser = \input ->
+        when left.parser input is
+            ShowVersion -> ShowVersion
+            ShowHelp sp -> ShowHelp sp
+            IncorrectUsage argExtractErr sp -> IncorrectUsage argExtractErr sp
+            SuccessfullyParsed { data, remainingArgs, subcommandPath } ->
+                when right.parser { args: remainingArgs, subcommandPath } is
+                    ShowVersion -> ShowVersion
+                    ShowHelp sp -> ShowHelp sp
+                    IncorrectUsage argExtractErr sp -> IncorrectUsage argExtractErr sp
+                    SuccessfullyParsed { data: data2, remainingArgs: restOfArgs, subcommandPath: nextSp } ->
+                        SuccessfullyParsed { data: combiner data data2, remainingArgs: restOfArgs, subcommandPath: nextSp }
+
+    @CliBuilder {
+        parser: combinedParser,
+        options: List.concat left.options right.options,
+        parameters: List.concat left.parameters right.parameters,
+        subcommands: Dict.insertAll left.subcommands right.subcommands,
+    }
 
 flagWasPassed : OptionConfig, List Arg -> Bool
 flagWasPassed = \option, args ->
@@ -107,7 +161,7 @@ flagWasPassed = \option, args ->
             Long long -> long.name == option.long
             Parameter _p -> Bool.false
 
-checkForHelpAndVersion : CliBuilder state action -> CliBuilder state action
+checkForHelpAndVersion : CliBuilder state fromAction toAction -> CliBuilder state fromAction toAction
 checkForHelpAndVersion = \@CliBuilder builder ->
     newParser = \{ args, subcommandPath } ->
         when builder.parser { args, subcommandPath } is
@@ -130,15 +184,15 @@ checkForHelpAndVersion = \@CliBuilder builder ->
 
 expect
     { parser } =
-        fromState (\x -> { x })
-        |> updateParser \{ data, remainingArgs } -> Ok { data: data (Inspect.toStr remainingArgs), remainingArgs: [] }
+        fromArgParser \args -> Ok { data: Inspect.toStr args, remainingArgs: [] }
+        |> map Inspected
         |> intoParts
 
     out = parser { args: [Parameter "123"], subcommandPath: [] }
 
     out
     == SuccessfullyParsed {
-        data: { x: "[(Parameter \"123\")]" },
+        data: Inspected "[(Parameter \"123\")]",
         remainingArgs: [],
         subcommandPath: [],
     }

--- a/platform/Arg/Cli.roc
+++ b/platform/Arg/Cli.roc
@@ -29,7 +29,7 @@
 ## ```roc
 ## fooSubcommand =
 ##     Opt.u64 { short: "a", help: "Set the alpha level" }
-##     |> Subcommand.finish {
+##     |> SubCmd.finish {
 ##         name: "foo",
 ##         description: "Foo some stuff."
 ##         mapper: Foo,
@@ -39,7 +39,7 @@
 ##     # We allow two subcommands of the same parent to have overlapping
 ##     # fields since only one can ever be parsed at a time.
 ##     Opt.u64 { short: "a", help: "Set the alpha level" }
-##     |> Subcommand.finish {
+##     |> SubCmd.finish {
 ##         name: "bar",
 ##         description: "Bar some stuff."
 ##         mapper: Bar,
@@ -47,7 +47,7 @@
 ##
 ## { Cli.combine <-
 ##     verbosity: Opt.count { short: "v", long: "verbose" },
-##     sc: Subcommand.optional [fooSubcommand, barSubcommand],
+##     sc: SubCmd.optional [fooSubcommand, barSubcommand],
 ## }
 ## ```
 ##

--- a/platform/Arg/Help.roc
+++ b/platform/Arg/Help.roc
@@ -7,8 +7,6 @@ import Arg.Base exposing [
     ParameterConfig,
     SubcommandConfig,
     SubcommandsConfig,
-    helpOption,
-    versionOption,
 ]
 import Arg.Utils exposing [toUpperCase, strLen]
 
@@ -66,9 +64,7 @@ findSubcommand = \command, path ->
 ##
 ## ```roc
 ## exampleCli =
-##     Cli.build {
-##         verbosity: <- Opt.count { short: "v", help: "How verbose our logs should be." },
-##     }
+##     Opt.count { short: "v", help: "How verbose our logs should be." }
 ##     |> Cli.finish {
 ##         name: "example",
 ##         version: "v0.1.0",
@@ -162,9 +158,7 @@ helpText = \baseConfig, path, textStyle ->
 ##
 ## ```roc
 ## exampleCli =
-##     Cli.build {
-##         verbosity: <- Opt.count { short: "v", help: "How verbose our logs should be." },
-##     }
+##     Opt.count { short: "v", help: "How verbose our logs should be." }
 ##     |> Cli.finish {
 ##         name: "example",
 ##         version: "v0.1.0",
@@ -188,16 +182,11 @@ usageHelp = \config, path, textStyle ->
 
     requiredOptions =
         options
-        |> List.keepIf \opt -> opt.plurality == One
+        |> List.dropIf \opt -> opt.expectedValue == NothingExpected
         |> List.map optionSimpleNameFormatter
 
-    noOtherOptions =
-        options
-        |> List.dropIf \opt -> opt.plurality == One || opt == helpOption || opt == versionOption
-        |> List.isEmpty
-
     otherOptions =
-        if noOtherOptions then
+        if List.len requiredOptions == List.len options then
             []
         else
             ["[options]"]

--- a/platform/Arg/SubCmd.roc
+++ b/platform/Arg/SubCmd.roc
@@ -36,7 +36,7 @@ SubcommandParserConfig subState : {
 ##         foo: Opt.str { short: "f" },
 ##         bar: Opt.str { short: "b" },
 ##     }
-##     |> Subcommand.finish { name: "foobar", description: "Foo and bar subcommand", mapper: FooBar }
+##     |> SubCmd.finish { name: "foobar", description: "Foo and bar subcommand", mapper: FooBar }
 ## ```
 finish : CliBuilder state fromAction toAction, { name : Str, description ? Str, mapper : state -> commonState } -> { name : Str, parser : ArgParser commonState, config : SubcommandConfig }
 finish = \builder, { name, description ? "", mapper } ->
@@ -95,14 +95,14 @@ getFirstArgToCheckForSubcommandCall = \{ remainingArgs, subcommandPath }, subcom
 ## expect
 ##     fooSubcommand =
 ##         Opt.str { short: "f" }
-##         |> Subcommand.finish { name: "foo", description: "Foo subcommand", mapper: Foo }
+##         |> SubCmd.finish { name: "foo", description: "Foo subcommand", mapper: Foo }
 ##
 ##     barSubcommand =
 ##         Opt.str { short: "b" }
-##         |> Subcommand.finish { name: "bar", description: "Bar subcommand", mapper: Bar }
+##         |> SubCmd.finish { name: "bar", description: "Bar subcommand", mapper: Bar }
 ##
 ##     { parser } =
-##         Subcommand.optional [fooSubcommand, barSubcommand],
+##         SubCmd.optional [fooSubcommand, barSubcommand],
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
@@ -154,14 +154,14 @@ optional = \subcommandConfigs ->
 ## expect
 ##     fooSubcommand =
 ##         Opt.str { short: "f" }
-##         |> Subcommand.finish { name: "foo", description: "Foo subcommand", mapper: Foo }
+##         |> SubCmd.finish { name: "foo", description: "Foo subcommand", mapper: Foo }
 ##
 ##     barSubcommand =
 ##         Opt.str { short: "b" }
-##         |> Subcommand.finish { name: "bar", description: "Bar subcommand", mapper: Bar }
+##         |> SubCmd.finish { name: "bar", description: "Bar subcommand", mapper: Bar }
 ##
 ##     { parser } =
-##         Subcommand.required [fooSubcommand, barSubcommand],
+##         SubCmd.required [fooSubcommand, barSubcommand],
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##

--- a/platform/Arg/Validate.roc
+++ b/platform/Arg/Validate.roc
@@ -40,7 +40,6 @@ CliValidationErr : [
 ##   - A long flag which is more than one character and kebab-case.
 ##   - Both a short and a long flag with the above requirements.
 ## - All parameters must be have kebab-case names.
-## - All custom option/parameter types are have kebab-case names.
 ## - No options can overlap, even between different subcommands, so long
 ##   as the options between the subcommands are ambiguous.
 ##   - For example, a CLI with a `-t` option at the root level and also


### PR DESCRIPTION
Update the Arg module to the new record builder syntax. I removed all references to the old builder syntax from `basic-cli` except for the ones in the `Task.batch` docs. It seems like that function should be removed since it only seems useful for old record builders, but that belongs in a different PR.

I copied (and adjusted) this code from Weaver, which I just released v0.3.0 for here: https://github.com/smores56/weaver/releases/tag/0.3.0