### PR TITLE
Update Tcp to use a heap like File

### DIFF
--- a/crates/roc_host/src/heap.rs
+++ b/crates/roc_host/src/heap.rs
@@ -77,7 +77,7 @@ impl<T> RefcountedResourceHeap<T> {
 
     pub fn alloc_for(self: &mut Self, data: T) -> Result<RocBox<()>> {
         self.0.alloc().map(|alloc_ptr| {
-            unsafe { *alloc_ptr = Refcounted(REFCOUNT_ONE, data) };
+            unsafe { std::ptr::write(alloc_ptr, Refcounted(REFCOUNT_ONE, data)) };
             let box_ptr = alloc_ptr as usize + mem::size_of::<usize>();
             unsafe { std::mem::transmute(box_ptr) }
         })

--- a/examples/tcp-client.roc
+++ b/examples/tcp-client.roc
@@ -23,22 +23,21 @@ handleErr = \error ->
                 $ ncat -e \$(which cat) -l 8085
                 """
 
-        TcpPerformErr (TcpReadBadUtf8 _) ->
+        TcpReadBadUtf8 _ ->
             Stderr.line "Received invalid UTF-8 data"
 
-        TcpPerformErr (TcpReadErr err) ->
+        TcpReadErr err ->
             errStr = Tcp.streamErrToStr err
             Stderr.line "Error while reading: $(errStr)"
 
-        TcpPerformErr (TcpWriteErr err) ->
+        TcpWriteErr err ->
             errStr = Tcp.streamErrToStr err
             Stderr.line "Error while writing: $(errStr)"
 
         other -> Stderr.line "Got other error: $(Inspect.toStr other)"
 
 run =
-    stream <- Tcp.withConnect "127.0.0.1" 8085
-
+    stream = Tcp.connect! "127.0.0.1" 8085
     Stdout.line! "Connected!"
 
     Task.loop {} \_ -> Task.map (tick stream) Step

--- a/platform/Effect.roc
+++ b/platform/Effect.roc
@@ -69,7 +69,7 @@ fileDelete : List U8 -> Effect (Result {} Str)
 fileReadBytes : List U8 -> Effect (Result (List U8) Str)
 
 FileReader := Box {}
-fileReader : List U8 -> Effect (Result FileReader Str)
+fileReader : List U8, U64 -> Effect (Result FileReader Str)
 fileReadLine : FileReader -> Effect (Result (List U8) Str)
 
 envDict : Effect (List (Str, Str))

--- a/platform/Effect.roc
+++ b/platform/Effect.roc
@@ -30,12 +30,13 @@ hosted Effect
         fileDelete,
         fileWriteUtf8,
         fileWriteBytes,
+        FileReader,
         fileReader,
         fileReadLine,
         pathType,
         posixTime,
+        TcpStream,
         tcpConnect,
-        tcpClose,
         tcpReadUpTo,
         tcpReadExactly,
         tcpReadUntil,
@@ -67,8 +68,9 @@ fileWriteUtf8 : List U8, Str -> Effect (Result {} Str)
 fileDelete : List U8 -> Effect (Result {} Str)
 fileReadBytes : List U8 -> Effect (Result (List U8) Str)
 
-fileReader : List U8, U64 -> Effect (Result (Box {}) Str)
-fileReadLine : Box {} -> Effect (Result (List U8) Str)
+FileReader := Box {}
+fileReader : List U8 -> Effect (Result FileReader Str)
+fileReadLine : FileReader -> Effect (Result (List U8) Str)
 
 envDict : Effect (List (Str, Str))
 envVar : Str -> Effect (Result Str {})
@@ -83,12 +85,12 @@ cwd : Effect (List U8)
 
 sendRequest : Box InternalHttp.Request -> Effect InternalHttp.InternalResponse
 
-tcpConnect : Str, U16 -> Effect (Result U64 Str)
-tcpClose : U64 -> Effect {}
-tcpReadUpTo : U64, U64 -> Effect (Result (List U8) Str)
-tcpReadExactly : U64, U64 -> Effect (Result (List U8) Str)
-tcpReadUntil : U64, U8 -> Effect (Result (List U8) Str)
-tcpWrite : U64, List U8 -> Effect (Result {} Str)
+TcpStream := Box {}
+tcpConnect : Str, U16 -> Effect (Result TcpStream Str)
+tcpReadUpTo : TcpStream, U64 -> Effect (Result (List U8) Str)
+tcpReadExactly : TcpStream, U64 -> Effect (Result (List U8) Str)
+tcpReadUntil : TcpStream, U8 -> Effect (Result (List U8) Str)
+tcpWrite : TcpStream, List U8 -> Effect (Result {} Str)
 
 pathType : List U8 -> Effect (Result InternalPath.InternalPathType (List U8))
 

--- a/platform/File.roc
+++ b/platform/File.roc
@@ -189,7 +189,7 @@ type : Str -> Task [IsFile, IsDir, IsSymLink] [PathErr MetadataErr]
 type = \path ->
     Path.type (Path.fromStr path)
 
-Reader := { reader : Box {}, path : Path }
+FileReader := { reader : Effect.FileReader, path : Path }
 
 ## Try to open a `File.Reader` for buffered (= part by part) reading given a path string.
 ## See [examples/file-read-buffered.roc](https://github.com/roc-lang/basic-cli/blob/main/examples/file-read-buffered.roc) for example usage.

--- a/platform/File.roc
+++ b/platform/File.roc
@@ -189,7 +189,7 @@ type : Str -> Task [IsFile, IsDir, IsSymLink] [PathErr MetadataErr]
 type = \path ->
     Path.type (Path.fromStr path)
 
-FileReader := { reader : Effect.FileReader, path : Path }
+Reader := { reader : Effect.FileReader, path : Path }
 
 ## Try to open a `File.Reader` for buffered (= part by part) reading given a path string.
 ## See [examples/file-read-buffered.roc](https://github.com/roc-lang/basic-cli/blob/main/examples/file-read-buffered.roc) for example usage.

--- a/platform/Tcp.roc
+++ b/platform/Tcp.roc
@@ -1,6 +1,6 @@
 module [
     Stream,
-    withConnect,
+    connect,
     readUpTo,
     readExactly,
     readUntil,
@@ -20,7 +20,7 @@ import InternalTask
 unexpectedEofErrorMessage = "UnexpectedEof"
 
 ## Represents a TCP stream.
-Stream := U64
+Stream := Effect.TcpStream
 
 ## Represents errors that can occur when connecting to a remote host.
 ConnectErr : [
@@ -70,39 +70,21 @@ parseStreamErr = \err ->
         "ErrorKind::BrokenPipe" -> BrokenPipe
         other -> Unrecognized other
 
-## Opens a TCP connection to a remote host and perform a [Task] with it.
+## Opens a TCP connection to a remote host.
 ##
 ## ```
-## # Connect to localhost:8080 and send "Hi from Roc!"
-## stream <- Tcp.withConnect "localhost" 8080
-## Tcp.writeUtf8 "Hi from Roc!" stream
+## # Connect to localhost:8080
+## stream = Tcp.connect! "localhost" 8080
 ## ```
 ##
-## The connection is automatically closed after the [Task] is completed. Examples of
+## The connection is automatically closed when the last reference to the stream is dropped.
+## Examples of
 ## valid hostnames:
 ##  - `127.0.0.1`
 ##  - `::1`
 ##  - `localhost`
 ##  - `roc-lang.org`
 ##
-withConnect : Str, U16, (Stream -> Task a err) -> Task a [TcpConnectErr ConnectErr, TcpPerformErr err]
-withConnect = \hostname, port, callback ->
-    stream =
-        connect hostname port
-            |> Task.mapErr! TcpConnectErr
-
-    result =
-        callback stream
-            |> Task.mapErr TcpPerformErr
-            |> Task.onErr!
-                (\err ->
-                    _ = close! stream
-                    Task.err err
-                )
-
-    close stream
-    |> Task.map \_ -> result
-
 connect : Str, U16 -> Task Stream ConnectErr
 connect = \host, port ->
     Effect.tcpConnect host port
@@ -110,12 +92,6 @@ connect = \host, port ->
         res
         |> Result.map @Stream
         |> Result.mapErr parseConnectErr
-    |> InternalTask.fromEffect
-
-close : Stream -> Task {} []
-close = \@Stream stream ->
-    Effect.tcpClose stream
-    |> Effect.map Ok
     |> InternalTask.fromEffect
 
 ## Read up to a number of bytes from the TCP stream.


### PR DESCRIPTION
When working on basic webserver, I realized the issue here. Overwriting a pointer with `*something = ...` in rust with drop the value already stored at the pointer. In our case, this meant dropping totally random uninitialized bytes as if they were a tcp stream. By using `std::ptr::write` we avoid the drop.

Otherwise, this PR just introduces auto free to tcp streams.