### PR TITLE
fix typo in Arg.roc

### DIFF
--- a/platform/Arg.roc
+++ b/platform/Arg.roc
@@ -30,7 +30,7 @@ list = \{} ->
 ## exampleCli =
 ##     { Cli.combine <-
 ##         verbosity: Opt.count { short: "v", help: "How verbose our logs should be." },
-##         alpha: Opt.mapbeU64 { short: "a", help: "Set the alpha level." },
+##         alpha: Opt.maybeU64 { short: "a", help: "Set the alpha level." },
 ##     }
 ##     |> Cli.finish {
 ##         name: "example",


### PR DESCRIPTION
Found this typo when learning roc and the Arg module.