### PR TITLE
Add `Stdin.readtoEnd`

### DIFF
--- a/crates/roc_host/src/glue.rs
+++ b/crates/roc_host/src/glue.rs
@@ -1,0 +1,104 @@
+use roc_std::roc_refcounted_noop_impl;
+use roc_std::RocRefcounted;
+use roc_std::RocStr;
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[repr(u8)]
+pub enum InternalIOErrTag {
+    BrokenPipe = 0,
+    Interrupted = 1,
+    InvalidInput = 2,
+    Other = 3,
+    OutOfMemory = 4,
+    UnexpectedEof = 5,
+    Unsupported = 6,
+    WouldBlock = 7,
+    WriteZero = 8,
+}
+
+impl core::fmt::Debug for InternalIOErrTag {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::BrokenPipe => f.write_str("InternalIOErr::BrokenPipe"),
+            Self::Interrupted => f.write_str("InternalIOErr::Interrupted"),
+            Self::InvalidInput => f.write_str("InternalIOErr::InvalidInput"),
+            Self::Other => f.write_str("InternalIOErr::Other"),
+            Self::OutOfMemory => f.write_str("InternalIOErr::OutOfMemory"),
+            Self::UnexpectedEof => f.write_str("InternalIOErr::UnexpectedEof"),
+            Self::Unsupported => f.write_str("InternalIOErr::Unsupported"),
+            Self::WouldBlock => f.write_str("InternalIOErr::WouldBlock"),
+            Self::WriteZero => f.write_str("InternalIOErr::WriteZero"),
+        }
+    }
+}
+
+roc_refcounted_noop_impl!(InternalIOErrTag);
+
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[repr(C)]
+pub struct InternalIOErr {
+    pub msg: roc_std::RocStr,
+    pub tag: InternalIOErrTag,
+}
+
+impl roc_std::RocRefcounted for InternalIOErr {
+    fn inc(&mut self) {
+        self.msg.inc();
+    }
+    fn dec(&mut self) {
+        self.msg.dec();
+    }
+    fn is_refcounted() -> bool {
+        true
+    }
+}
+
+impl From<std::io::Error> for InternalIOErr {
+    fn from(e: std::io::Error) -> Self {
+        match e.kind() {
+            std::io::ErrorKind::BrokenPipe => InternalIOErr {
+                tag: InternalIOErrTag::BrokenPipe,
+                msg: RocStr::empty(),
+            },
+            std::io::ErrorKind::OutOfMemory => InternalIOErr {
+                tag: InternalIOErrTag::OutOfMemory,
+                msg: RocStr::empty(),
+            },
+            std::io::ErrorKind::WriteZero => InternalIOErr {
+                tag: InternalIOErrTag::WriteZero,
+                msg: RocStr::empty(),
+            },
+            std::io::ErrorKind::ConnectionAborted
+            | std::io::ErrorKind::ConnectionReset
+            | std::io::ErrorKind::NotConnected
+            | std::io::ErrorKind::UnexpectedEof => InternalIOErr {
+                tag: InternalIOErrTag::UnexpectedEof,
+                msg: RocStr::empty(),
+            },
+            std::io::ErrorKind::Interrupted => InternalIOErr {
+                tag: InternalIOErrTag::Interrupted,
+                msg: RocStr::empty(),
+            },
+            std::io::ErrorKind::InvalidData | std::io::ErrorKind::InvalidInput => InternalIOErr {
+                tag: InternalIOErrTag::InvalidInput,
+                msg: RocStr::empty(),
+            },
+            std::io::ErrorKind::TimedOut => InternalIOErr {
+                tag: InternalIOErrTag::WouldBlock,
+                msg: RocStr::empty(),
+            },
+            std::io::ErrorKind::WouldBlock => InternalIOErr {
+                tag: InternalIOErrTag::WouldBlock,
+                msg: RocStr::empty(),
+            },
+            std::io::ErrorKind::AddrInUse | std::io::ErrorKind::AddrNotAvailable => InternalIOErr {
+                tag: InternalIOErrTag::Unsupported,
+                msg: RocStr::empty(),
+            },
+            _ => InternalIOErr {
+                tag: InternalIOErrTag::Other,
+                msg: format!("{}", e).as_str().into(),
+            },
+        }
+    }
+}

--- a/crates/roc_host/src/lib.rs
+++ b/crates/roc_host/src/lib.rs
@@ -21,6 +21,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{env, io};
 use tokio::runtime::Runtime;
 
+mod glue;
+
 thread_local! {
    static TOKIO_RUNTIME: Runtime = tokio::runtime::Builder::new_current_thread()
        .enable_io()
@@ -466,6 +468,16 @@ pub extern "C" fn roc_fx_stdinBytes() -> RocResult<RocList<u8>, ()> {
     match stdin.lock().read(&mut buffer) {
         Ok(bytes_read) => RocResult::ok(RocList::from(&buffer[0..bytes_read])),
         Err(_) => RocResult::ok(RocList::from(([]).as_slice())),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_stdinReadToEnd() -> RocResult<RocList<u8>, glue::InternalIOErr> {
+    let stdin = std::io::stdin();
+    let mut buf = Vec::new();
+    match stdin.lock().read_to_end(&mut buf) {
+        Ok(bytes_read) => RocResult::ok(RocList::from(&buf[0..bytes_read])),
+        Err(err) => RocResult::err(err.into()),
     }
 }
 

--- a/platform/Arg/Param.roc
+++ b/platform/Arg/Param.roc
@@ -66,7 +66,7 @@ builderWithParameterParser : ParameterConfig, (List Str -> Result data ArgExtrac
 builderWithParameterParser = \param, valueParser ->
     argParser = \args ->
         { values, remainingArgs } = extractParamValues? { args, param }
-        
+
         data = valueParser? values
 
         Ok { data, remainingArgs }

--- a/platform/PlatformTasks.roc
+++ b/platform/PlatformTasks.roc
@@ -1,5 +1,6 @@
 hosted PlatformTasks
     exposes [
+        InternalIOErr,
         args,
         dirList,
         dirCreate,
@@ -17,6 +18,7 @@ hosted PlatformTasks
         stderrWrite,
         stdinLine,
         stdinBytes,
+        stdinReadToEnd,
         ttyModeCanonical,
         ttyModeRaw,
         sendRequest,
@@ -47,12 +49,28 @@ hosted PlatformTasks
         InternalPath,
     ]
 
+InternalIOErr : {
+    tag : [
+        BrokenPipe,
+        WouldBlock,
+        WriteZero,
+        Unsupported,
+        Interrupted,
+        OutOfMemory,
+        UnexpectedEof,
+        InvalidInput,
+        Other,
+    ],
+    msg : Str,
+}
+
 stdoutLine : Str -> Task {} Str
 stdoutWrite : Str -> Task {} Str
 stderrLine : Str -> Task {} Str
 stderrWrite : Str -> Task {} Str
-stdinLine :  Task Str Str
+stdinLine : Task Str Str
 stdinBytes : Task (List U8) {}
+stdinReadToEnd : Task (List U8) InternalIOErr
 ttyModeCanonical : Task {} {}
 ttyModeRaw : Task {} {}
 

--- a/platform/glue.roc
+++ b/platform/glue.roc
@@ -1,0 +1,24 @@
+platform ""
+    requires {} { main : _ }
+    exposes []
+    packages {}
+    imports []
+    provides [mainForHost]
+
+InternalIOErr : {
+    tag : [
+        BrokenPipe,
+        WouldBlock,
+        WriteZero,
+        Unsupported,
+        Interrupted,
+        OutOfMemory,
+        UnexpectedEof,
+        InvalidInput,
+        Other,
+    ],
+    msg : Str,
+}
+
+mainForHost : InternalIOErr
+mainForHost = main


### PR DESCRIPTION
I was doing an AoC puzzle and wanted to read all the bytes from a file piped to stdin using `roc app.roc < input.txt`, however using `Stdin.bytes` is buffered to 256 bytes at a time. This effect is more suitable as it will read until `EOF`.