### PR TITLE
fix: Str.splitOn -> Str.split

### DIFF
--- a/examples/file-read.roc
+++ b/examples/file-read.roc
@@ -20,6 +20,6 @@ main =
 run =
     fileName = "LICENSE"
     contents = File.readUtf8! fileName
-    lines = Str.splitOn contents "\n"
+    lines = Str.split contents "\n"
 
     Stdout.line (Str.concat "First line of $(fileName): " (List.first lines |> Result.withDefault "err"))

--- a/platform/Arg/Help.roc
+++ b/platform/Arg/Help.roc
@@ -339,7 +339,7 @@ indentMultilineStringBy = \string, indentAmount ->
     indentation = Str.repeat " " indentAmount
 
     string
-    |> Str.splitOn "\n"
+    |> Str.split "\n"
     |> List.mapWithIndex \line, index ->
         if index == 0 then
             line


### PR DESCRIPTION
Discovered the following error when attempting to import the `Arg` module.

```roc
── NOT EXPOSED in .../lZFLstMUCUvd5bjnnpYromZJXkQUrdhbva4xdBInicE/Arg/Help.roc ─

The Str module does not expose `splitOn`:

342│      |> Str.splitOn "\n"
             ^^^^^^^^^^^

Did you mean one of these?

    Str.split
    Str.splitLast
    Str.splitFirst
    Str.isEmpty

────────────────────────────────────────────────────────────────────────────────

1 error and 1 warning found in 47 ms
```

This PR fixes this and one other occurrence of the `Str.splitOn` function.

This error was triggered with the following compiler version:
```
roc nightly pre-release, built from commit 8dbc909 on Fr 15 Nov 2024 09:02:07 UTC
```