### PR TITLE
Delete outdated .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# ignore glue generated files
-platform/src/main_glue/**/* linguist-generated=true


### PR DESCRIPTION
This seems outdated. Should we delete or update it? It references `platform/src/` which no longer exists, but `crates/roc_host_src/glue.rs` was added in `0.16.0`.