### PR TITLE
Replace the current file IO solution with one that uses roc buffers

### DIFF
--- a/crates/roc_host/src/lib.rs
+++ b/crates/roc_host/src/lib.rs
@@ -7,15 +7,12 @@
 #![allow(improper_ctypes)]
 use core::ffi::c_void;
 use core::panic;
-use hyper::body::Buf;
 use roc_std::{RocBox, RocList, RocRefcounted, RocResult, RocStr};
 use roc_std_heap::ThreadSafeRefcountedResourceHeap;
 use std::borrow::{Borrow, Cow};
 use std::ffi::OsStr;
-use std::fmt::Debug;
 use std::fs::File;
-use std::io::{BufRead, BufReader, ErrorKind, IsTerminal, Read, Seek, Write};
-use std::mem::ManuallyDrop;
+use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
 use std::net::TcpStream;
 use std::path::Path;
 use std::sync::OnceLock;

--- a/platform/File.roc
+++ b/platform/File.roc
@@ -16,6 +16,7 @@ module [
     openReader!,
     openReaderWithCapacity!,
     readLine!,
+    readBytesBuf!,
 ]
 
 import Path exposing [Path, MetadataErr]
@@ -236,4 +237,9 @@ openReaderWithCapacity! = \pathStr, capacity ->
 readLine! : Reader => Result (List U8) [FileReadErr Path Str]
 readLine! = \@Reader { reader, path } ->
     PlatformTasks.fileReadLine! reader
+    |> Result.mapErr \err -> FileReadErr path err
+
+readBytesBuf! : Reader,List U8 => Result (List U8) [FileReadErr Path Str]
+readBytesBuf! = \@Reader { reader, path },buf ->
+    PlatformTasks.fileReadByteBuf! reader buf
     |> Result.mapErr \err -> FileReadErr path err

--- a/platform/File.roc
+++ b/platform/File.roc
@@ -15,6 +15,7 @@ module [
     Reader,
     openReader!,
     openReaderWithCapacity!,
+    openReaderWithBuf!,
     readLine!,
     readBytesBuf!,
 ]
@@ -243,3 +244,13 @@ readBytesBuf! : Reader,List U8 => Result (List U8) [FileReadErr Path Str]
 readBytesBuf! = \@Reader { reader, path },buf ->
     PlatformTasks.fileReadByteBuf! reader buf
     |> Result.mapErr \err -> FileReadErr path err
+
+# TODO! This returns a FIle but isn't actually the same as other readers so it would break if i use it in another reader    
+openReaderWithBuf! : Str, List U8 => Result Reader [GetFileReadErr Path ReadErr]
+openReaderWithBuf! = \pathStr, capacity ->
+    path = Path.fromStr pathStr
+
+    PlatformTasks.fileReaderRocBuf! (Str.toUtf8 pathStr) capacity
+    |> Result.mapErr \err -> GetFileReadErr path (InternalFile.handleReadErr err)
+    |> Result.map \reader -> @Reader { reader, path }
+

--- a/platform/File.roc
+++ b/platform/File.roc
@@ -7,6 +7,7 @@ module [
     readUtf8!,
     readBytes!,
     # read, TODO fix "Ability specialization is unknown - code generation cannot proceed!: DeriveError(UnboundVar)"
+    read!,
     delete!,
     isDir!,
     isFile!,
@@ -17,9 +18,9 @@ module [
     openReaderWithCapacity!,
     openReaderWithBuf!,
     readLine!,
-    readBytesBuf!,
+    readBytesToBuf!,
 ]
-
+# import Shared exposing [ByteReader]
 import Path exposing [Path, MetadataErr]
 import InternalFile
 import PlatformTasks
@@ -195,62 +196,85 @@ type! : Str => Result [IsFile, IsDir, IsSymLink] [PathErr MetadataErr]
 type! = \path ->
     Path.type! (Path.fromStr path)
 
-Reader := { reader : PlatformTasks.FileReader, path : Path }
+Reader := { reader : PlatformTasks.FileReader, path : Path, buffer : List U8 }
 
 ## Try to open a `File.Reader` for buffered (= part by part) reading given a path string.
 ## See [examples/file-read-buffered.roc](https://github.com/roc-lang/basic-cli/blob/main/examples/file-read-buffered.roc) for example usage.
-##
-## This uses [rust's std::io::BufReader](https://doc.rust-lang.org/std/io/struct.BufReader.html).
 ##
 ## Use [readUtf8!] if you want to get the entire file contents at once.
 openReader! : Str => Result Reader [GetFileReadErr Path ReadErr]
 openReader! = \pathStr ->
     path = Path.fromStr pathStr
+    buffer = List.withCapacity 8000
 
     # 0 means with default capacity
-    PlatformTasks.fileReader! (Str.toUtf8 pathStr) 0
+    PlatformTasks.fileReader! (Str.toUtf8 pathStr)
     |> Result.mapErr \err -> GetFileReadErr path (InternalFile.handleReadErr err)
-    |> Result.map \reader -> @Reader { reader, path }
+    |> Result.map \reader -> @Reader { reader, path, buffer }
 
 ## Try to open a `File.Reader` for buffered (= part by part) reading given a path string.
 ## The buffer will be created with the specified capacity.
 ## See [examples/file-read-buffered.roc](https://github.com/roc-lang/basic-cli/blob/main/examples/file-read-buffered.roc) for example usage.
 ##
-## This uses [rust's std::io::BufReader](https://doc.rust-lang.org/std/io/struct.BufReader.html).
-##
 ## Use [readUtf8!] if you want to get the entire file contents at once.
 openReaderWithCapacity! : Str, U64 => Result Reader [GetFileReadErr Path ReadErr]
 openReaderWithCapacity! = \pathStr, capacity ->
     path = Path.fromStr pathStr
+    # 8k is the default in rust and seems reasonable
+    buffer = List.withCapacity (if capacity == 0 then 8000 else capacity)
 
-    PlatformTasks.fileReader! (Str.toUtf8 pathStr) capacity
+    PlatformTasks.fileReader! (Str.toUtf8 pathStr)
     |> Result.mapErr \err -> GetFileReadErr path (InternalFile.handleReadErr err)
-    |> Result.map \reader -> @Reader { reader, path }
+    |> Result.map \reader -> @Reader { reader, path, buffer }
 
 ## Try to read a line from a file given a Reader.
 ## The line will be provided as the list of bytes (`List U8`) until a newline (`0xA` byte).
 ## This list will be empty when we reached the end of the file.
 ## See [examples/file-read-buffered.roc](https://github.com/roc-lang/basic-cli/blob/main/examples/file-read-buffered.roc) for example usage.
 ##
-## This uses [rust's `BufRead::read_line`](https://doc.rust-lang.org/std/io/trait.BufRead.html#method.read_line).
-##
 ## Use [readUtf8!] if you want to get the entire file contents at once.
 readLine! : Reader => Result (List U8) [FileReadErr Path Str]
-readLine! = \@Reader { reader, path } ->
-    PlatformTasks.fileReadLine! reader
+readLine! = \@Reader { reader, path, buffer } ->
+    PlatformTasks.fileReadLine! reader buffer
     |> Result.mapErr \err -> FileReadErr path err
 
-readBytesBuf! : Reader,List U8 => Result (List U8) [FileReadErr Path Str]
-readBytesBuf! = \@Reader { reader, path },buf ->
-    PlatformTasks.fileReadByteBuf! reader buf
+## Try to read bytes from a file given a Reader.
+## Returns a list of bytes (`List U8`) read from the file.
+## The list will be empty when we reach the end of the file.
+## See [examples/file-read-buffered.roc](https://github.com/roc-lang/basic-cli/blob/main/examples/file-read-buffered.roc) for example usage.
+##
+## NOTE: Avoid storing a reference to the buffer returned by this function beyond the next call to try readBytes. 
+## That will allow the buffer to be reused and avoid unnecessary allocations.
+##
+## Use [readUtf8!] if you want to get the entire file contents at once as a UTF-8 string.
+read! : Reader => Result (List U8) [FileReadErr Path Str]
+read! = \@Reader { reader, path, buffer } ->
+    PlatformTasks.fileReadByteBuf! reader buffer
     |> Result.mapErr \err -> FileReadErr path err
 
-# TODO! This returns a FIle but isn't actually the same as other readers so it would break if i use it in another reader    
+## Try to open a `File.Reader` using the provided buffer as the internal buffer.
+## See [examples/file-read-buffered.roc](https://github.com/roc-lang/basic-cli/blob/main/examples/file-read-buffered.roc) for example usage.
+##
+## Use [readUtf8!] if you want to get the entire file contents at once.
 openReaderWithBuf! : Str, List U8 => Result Reader [GetFileReadErr Path ReadErr]
-openReaderWithBuf! = \pathStr, capacity ->
+openReaderWithBuf! = \pathStr, buffer ->
     path = Path.fromStr pathStr
 
-    PlatformTasks.fileReaderRocBuf! (Str.toUtf8 pathStr) capacity
+    PlatformTasks.fileReader! (Str.toUtf8 pathStr) 
     |> Result.mapErr \err -> GetFileReadErr path (InternalFile.handleReadErr err)
-    |> Result.map \reader -> @Reader { reader, path }
+    |> Result.map \reader -> @Reader { reader, path, buffer }
+
+
+## Try to read bytes from a file given a Reader.
+## Returns a list of bytes (`List U8`) read from the file.
+## The list will be empty when we reach the end of the file.
+## This function is exists for very specific use cases where you want to use multiple buffers with a single reader
+##
+## Prefer [File.readBytes!] which will automatically reuse the reader's internalbuffer.
+readBytesToBuf! : Reader => Result (List U8) [FileReadErr Path Str]
+readBytesToBuf! = \@Reader { reader, path, buffer } ->
+    PlatformTasks.fileReadByteBuf! reader buffer
+    |> Result.mapErr \err -> FileReadErr path err
+
+    
 

--- a/platform/PlatformTasks.roc
+++ b/platform/PlatformTasks.roc
@@ -29,6 +29,7 @@ hosted PlatformTasks
         fileWriteUtf8!,
         fileWriteBytes!,
         fileReader!,
+        fileReaderRocBuf!,
         fileReadLine!,
         fileReadByteBuf!,
         pathType!,
@@ -85,6 +86,7 @@ fileReadBytes! : List U8 => Result (List U8) Str
 
 FileReader := Box {}
 fileReader! : List U8, U64 => Result FileReader Str
+fileReaderRocBuf! : List U8,List U8=> Result FileReader Str
 fileReadLine! : FileReader => Result (List U8) Str
 fileReadByteBuf! : FileReader, List U8 => Result (List U8) Str
 

--- a/platform/PlatformTasks.roc
+++ b/platform/PlatformTasks.roc
@@ -29,7 +29,6 @@ hosted PlatformTasks
         fileWriteUtf8!,
         fileWriteBytes!,
         fileReader!,
-        fileReaderRocBuf!,
         fileReadLine!,
         fileReadByteBuf!,
         pathType!,
@@ -85,10 +84,9 @@ fileDelete! : List U8 => Result {} Str
 fileReadBytes! : List U8 => Result (List U8) Str
 
 FileReader := Box {}
-fileReader! : List U8, U64 => Result FileReader Str
-fileReaderRocBuf! : List U8,List U8=> Result FileReader Str
-fileReadLine! : FileReader => Result (List U8) Str
-fileReadByteBuf! : FileReader, List U8 => Result (List U8) Str
+fileReader! : List U8 => Result FileReader Str
+fileReadLine! : FileReader,List U8 => Result (List U8) Str
+fileReadByteBuf! : FileReader, List U8=> Result (List U8) Str
 
 envDict! : {} => List (Str, Str)
 envVar! : Str => Result Str {}

--- a/platform/PlatformTasks.roc
+++ b/platform/PlatformTasks.roc
@@ -30,6 +30,7 @@ hosted PlatformTasks
         fileWriteBytes!,
         fileReader!,
         fileReadLine!,
+        fileReadByteBuf!,
         pathType!,
         posixTime!,
         tcpConnect!,
@@ -85,6 +86,7 @@ fileReadBytes! : List U8 => Result (List U8) Str
 FileReader := Box {}
 fileReader! : List U8, U64 => Result FileReader Str
 fileReadLine! : FileReader => Result (List U8) Str
+fileReadByteBuf! : FileReader, List U8 => Result (List U8) Str
 
 envDict! : {} => List (Str, Str)
 envVar! : Str => Result Str {}


### PR DESCRIPTION
This replaces the existing buffered IO with a method using only roc buffers.  

Massively improves performance in my testing

See this conversation for many benchmarks:
https://roc.zulipchat.com/#narrow/channel/302903-platform-development/topic/Returning.20a.20modified.20roc.20list.20from.20a.20rust.20platform

Some highlights:
```
Benchmark 1 (61 runs): ./buf-reuse
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          81.8ms ± 3.21ms    75.2ms … 97.4ms          5 ( 8%)        0%
  peak_rss           2.75MB ± 16.8KB    2.62MB … 2.75MB          1 ( 2%)        0%
  cpu_cycles         6.96M  ±  336K     6.79M  … 8.70M           7 (11%)        0%
  instructions       10.1M  ± 2.16      10.1M  … 10.1M           0 ( 0%)        0%
  cache_references   20.6K  ±  751      17.1K  … 22.1K           1 ( 2%)        0%
  cache_misses       12.1K  ±  623      9.00K  … 13.3K           1 ( 2%)        0%
  branch_misses      4.75K  ±  340      3.79K  … 5.58K           3 ( 5%)        0%
Benchmark 2 (7 runs): ./readWhole
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           812ms ± 3.87ms     808ms …  818ms          0 ( 0%)        💩+892.2% ±  3.2%
  peak_rss            822MB ± 70.1KB     822MB …  822MB          0 ( 0%)        💩+29773.0% ±  0.8%
  cpu_cycles          984M  ± 8.03M      978M  … 1.00G           0 ( 0%)        💩+14037.7% ± 28.0%
  instructions       3.28G  ± 34.8      3.28G  … 3.28G           0 ( 0%)        💩+32490.8% ±  0.0%
  cache_references   5.89M  ± 30.8K     5.84M  … 5.94M           0 ( 0%)        💩+28474.6% ± 36.1%
  cache_misses       1.65M  ± 9.12K     1.63M  … 1.66M           0 ( 0%)        💩+13588.0% ± 18.6%
  branch_misses      4.93K  ±  188      4.62K  … 5.12K           0 ( 0%)          +  3.9% ±  5.5%
Benchmark 3 (22 runs): ./readWhole-new
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           236ms ± 4.43ms     230ms …  249ms          1 ( 5%)        💩+189.0% ±  2.2%
  peak_rss            412MB ± 59.7KB     412MB …  412MB          0 ( 0%)        💩+14881.8% ±  0.6%
  cpu_cycles          726K  ± 59.9K      645K  …  923K           1 ( 5%)        ⚡- 89.6% ±  2.1%
  instructions        483K  ± 0.46       483K  …  483K           0 ( 0%)        ⚡- 95.2% ±  0.0%
  cache_references   9.76K  ±  250      8.97K  … 10.2K           1 ( 5%)        ⚡- 52.7% ±  1.6%
  cache_misses       7.69K  ±  320      7.03K  … 8.67K           2 ( 9%)        ⚡- 36.2% ±  2.3%
  branch_misses      4.73K  ±  153      4.50K  … 5.17K           0 ( 0%)          -  0.5% ±  3.2%
```
