### PR TITLE
Delete no-op line of glue input

### DIFF
--- a/platform/glue.roc
+++ b/platform/glue.roc
@@ -7,7 +7,5 @@ platform ""
 
 import Host
 
-InternalIOErr : Host.InternalIOErr
-
-mainForHost : InternalIOErr
+mainForHost : Host.InternalIOErr
 mainForHost = main


### PR DESCRIPTION
I just realized that `RustGlue.roc` seems to ignore this alias, so we might as well not pretend it's doing anything.