### PR TITLE
rust_host_bin: pass -Wl,-headerpad,0x1000 to reserve space for the surgical linker

### DIFF
--- a/crates/roc_host_bin/build.rs
+++ b/crates/roc_host_bin/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // Make sure we have enough free space for additional load commands
+    // that we expect the surgical linker to add to the preprocessed host.
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-arg=-Wl,-headerpad,0x1000")
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,5 +6,6 @@
 #     b) update `channel = "nightly-OLD_DATE"` below
 
 channel = "1.82.0" # check ^^^ when changing this
+components = ["rust-analyzer"]
 #
 # channel = "nightly-2024-04-28" # 1.79.0 nightly to be able to use unstable features


### PR DESCRIPTION
Also, add `rust-analyzer` component to `rust-toolchain.toml`.