### PR TITLE
Replace invalid ? operator with try

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1737571712,
-        "narHash": "sha256-r66c44RYt/0jOtqn44FNmRaWvxL3wGHtU9MCtsc3Omc=",
+        "lastModified": 1737834704,
+        "narHash": "sha256-pmOKnFICkke5q3HP1FmwvilTMM+Ui+zfWjkKgL2umrw=",
         "owner": "roc-lang",
         "repo": "roc",
-        "rev": "c5a464458ab801df7a2aed0962ba5b3e7c055d37",
+        "rev": "3f09235d6afcf4fde3861e6546f521004d6de8b0",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737599167,
-        "narHash": "sha256-S2rHCrQWCDVp63XxL/AQbGr1g5M8Zx14C7Jooa4oM8o=",
+        "lastModified": 1737944843,
+        "narHash": "sha256-ZSXR/po/slqpsk3JLVjXbE04Vqrb4k7yCGHjyMj3tOk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "38374302ae9edf819eac666d1f276d62c712dd06",
+        "rev": "27bb917a41480b6ceee8e42d32dfcc9ecc6fa6c6",
         "type": "github"
       },
       "original": {

--- a/platform/Path.roc
+++ b/platform/Path.roc
@@ -307,7 +307,8 @@ read_utf8! : Path => Result Str [FileReadErr Path IOErr, FileReadUtf8Err Path _]
 read_utf8! = |path|
     bytes =
         Host.file_read_bytes!(InternalPath.to_bytes(path))
-        |> Result.map_err?(|read_err| FileReadErr(path, InternalIOErr.handle_err(read_err)))
+        |> Result.map_err(|read_err| FileReadErr(path, InternalIOErr.handle_err(read_err)))
+        |> try
 
     Str.from_utf8(bytes)
     |> Result.map_err(|err| FileReadUtf8Err(path, err))

--- a/platform/Path.roc
+++ b/platform/Path.roc
@@ -307,8 +307,7 @@ read_utf8! : Path => Result Str [FileReadErr Path IOErr, FileReadUtf8Err Path _]
 read_utf8! = |path|
     bytes =
         Host.file_read_bytes!(InternalPath.to_bytes(path))
-        |> Result.map_err(|read_err| FileReadErr(path, InternalIOErr.handle_err(read_err)))
-        |> try
+        |> Result.map_err(|read_err| FileReadErr(path, InternalIOErr.handle_err(read_err)))?
 
     Str.from_utf8(bytes)
     |> Result.map_err(|err| FileReadUtf8Err(path, err))


### PR DESCRIPTION
Path.roc had an invalid use of the `?` operator. This should be placed after the last paren on the function call, instead of before the opening paren.

<img width="755" alt="Screenshot 2025-01-27 at 09 38 26" src="https://github.com/user-attachments/assets/80eb8e90-646f-430d-9d1f-60ba082d9e33" />