### PR TITLE
Snake-case-ify function names in example output

### DIFF
--- a/ci/expect_scripts/path.exp
+++ b/ci/expect_scripts/path.exp
@@ -10,7 +10,7 @@ source ./ci/expect_scripts/shared-code.exp
 cd $env(EXAMPLES_DIR)
 spawn ./path
 
-expect "isFile: Bool.true isDir: Bool.false isSymLink: Bool.false type: IsFile\r\n" {
+expect "is_file: Bool.true is_dir: Bool.false is_sym_link: Bool.false type: IsFile\r\n" {
     expect eof {
         check_exit_and_segfault
     }

--- a/examples/path.roc
+++ b/examples/path.roc
@@ -14,4 +14,4 @@ main! = |_args|
     c = Path.is_sym_link!(path)?
     d = Path.type!(path)?
 
-    Stdout.line!("isFile: ${Inspect.to_str(a)} isDir: ${Inspect.to_str(b)} isSymLink: ${Inspect.to_str(c)} type: ${Inspect.to_str(d)}")
+    Stdout.line!("is_file: ${Inspect.to_str(a)} is_dir: ${Inspect.to_str(b)} is_sym_link: ${Inspect.to_str(c)} type: ${Inspect.to_str(d)}")


### PR DESCRIPTION
This just seems like a leftover that the formatter can't (and shouldn't) catch.

CC @lukewilliamboswell @smores56 