### PR TITLE
Clarify dir names in example

### DIFF
--- a/examples/dir.roc
+++ b/examples/dir.roc
@@ -9,33 +9,33 @@ import pf.Path
 main! = |_args|
 
     # Create a directory
-    Dir.create!("dirExampleE")?
+    Dir.create!("empty-dir")?
 
     # Create a directory and its parents
-    Dir.create_all!("dirExampleA/b/c/child")?
+    Dir.create_all!("nested-dir/a/b/c")?
 
     # Create a child directory
-    Dir.create!("dirExampleA/child")?
+    Dir.create!("nested-dir/child")?
 
     # List the contents of a directory
     paths_as_str =
-        Dir.list!("dirExampleA")
+        Dir.list!("nested-dir")
         |> Result.map_ok(|paths| List.map(paths, Path.display))
         |> try
 
     # Check the contents of the directory
-    expect Set.from_list(paths_as_str) == Set.from_list(["dirExampleA/b", "dirExampleA/child"])
+    expect Set.from_list(paths_as_str) == Set.from_list(["nested-dir/a", "nested-dir/child"])
 
     # Try to create a directory without a parent (should fail, ignore error)
-    when Dir.create!("dirExampleD/child") is
+    when Dir.create!("another-dir/child") is
         Ok({}) -> {}
         Err(_) -> {}
 
     # Delete an empty directory
-    Dir.delete_empty!("dirExampleE")?
+    Dir.delete_empty!("empty-dir")?
 
     # Delete all directories recursively
-    Dir.delete_all!("dirExampleA")?
+    Dir.delete_all!("nested-dir")?
 
     Stdout.line!("Success!")?
 


### PR DESCRIPTION
`empty-dir`, `nested-dir`, and `another-dir` are much easier to understand than `dirExampleE`, `dirExampleA`, and `dirExampleD`.

CC @lukewilliamboswell @smores56 