### PR TITLE
Snake-case-ify ignored function parameters

### DIFF
--- a/platform/EnvDecoding.roc
+++ b/platform/EnvDecoding.roc
@@ -104,7 +104,7 @@ env_list = |decode_elem|
 # exercised, and the solver can find an ambient lambda set for the
 # specialization.
 env_record : _, (_, _ -> [Keep (Decoder _ _), Skip]), (_, _ -> _) -> Decoder _ _
-env_record = |_initialState, _stepField, _finalizer|
+env_record = |_initial_state, _step_field, _finalizer|
     Decode.custom(
         |bytes, @EnvFormat({})|
             { result: Err(TooShort), rest: bytes },
@@ -114,7 +114,7 @@ env_record = |_initialState, _stepField, _finalizer|
 # exercised, and the solver can find an ambient lambda set for the
 # specialization.
 env_tuple : _, (_, _ -> [Next (Decoder _ _), TooLong]), (_ -> _) -> Decoder _ _
-env_tuple = |_initialState, _stepElem, _finalizer|
+env_tuple = |_initial_state, _step_elem, _finalizer|
     Decode.custom(
         |bytes, @EnvFormat({})|
             { result: Err(TooShort), rest: bytes },


### PR DESCRIPTION
It looks like the formatter missed these [when snake-case-ing](https://github.com/roc-lang/basic-cli/commit/349a4993b25b256dc0a7224168095b78a8ef4efa#diff-58bd4936b20e4a6ea65ebe5321ce8b57c8c9972e87bb703b1be0724a2947e802R100-R107) and [when `|args|`-ing](https://github.com/roc-lang/basic-cli/pull/314).

CC @lukewilliamboswell @smores56 