### PR TITLE
HTTP: Don't expect request bodies to be UTF-8

### DIFF
--- a/crates/roc_host/src/lib.rs
+++ b/crates/roc_host/src/lib.rs
@@ -559,7 +559,7 @@ pub extern "C" fn roc_fx_send_request(
     })
 }
 
-async fn async_send_request(request: hyper::Request<String>) -> roc_http::ResponseToAndFromHost {
+async fn async_send_request(request: hyper::Request<hyper::Body>) -> roc_http::ResponseToAndFromHost {
     use hyper::Client;
     use hyper_rustls::HttpsConnectorBuilder;
 
@@ -569,7 +569,7 @@ async fn async_send_request(request: hyper::Request<String>) -> roc_http::Respon
         .enable_http1()
         .build();
 
-    let client: Client<_, String> = Client::builder().build(https);
+    let client: Client<_, hyper::Body> = Client::builder().build(https);
     let res = client.request(request).await;
 
     match res {

--- a/crates/roc_http/src/lib.rs
+++ b/crates/roc_http/src/lib.rs
@@ -132,7 +132,7 @@ impl RequestToAndFromHost {
         }
     }
 
-    pub fn to_hyper_request(&self) -> Result<hyper::Request<String>, hyper::http::Error> {
+    pub fn to_hyper_request(&self) -> Result<hyper::Request<hyper::Body>, hyper::http::Error> {
         let method: hyper::Method = self.as_hyper_method();
         let mut req_builder = hyper::Request::builder()
             .method(method)
@@ -153,7 +153,7 @@ impl RequestToAndFromHost {
             req_builder = req_builder.header("Content-Type", "text/plain");
         }
 
-        let bytes = String::from_utf8(self.body.as_slice().to_vec()).unwrap();
+        let bytes = hyper::Body::from(self.body.as_slice().to_vec());
 
         req_builder.body(bytes)
     }


### PR DESCRIPTION
Using UTF-8 strings for the request bodies is probably a remnant from times past. The bodies are raw bytes on the Roc-side and here we align with that. This enables requests like file uploads etc. which aren't UTF-8 strings.