### PR TITLE
Strip Linux hosts from release bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           version: nightly-new-compiler
       - uses: dtolnay/rust-toolchain@1.83.0
         with:
+          components: llvm-tools-preview
           targets: x86_64-unknown-linux-musl
       - name: Format, check, and test examples
         run: ./scripts/test.py --operation validate
@@ -83,6 +84,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.83.0
         with:
           targets: ${{ matrix.rust_target }}
+      - name: Install LLVM tools for Linux host stripping
+        if: endsWith(matrix.target, 'musl')
+        run: rustup component add llvm-tools-preview
       - name: Cross-compile every example
         shell: bash
         run: ./scripts/test.py --operation build --target "${{ matrix.target }}" --artifact-dir dist/example-binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Install Rust with cross-compilation targets
         uses: dtolnay/rust-toolchain@1.83.0
         with:
+          components: llvm-tools-preview
           targets: x86_64-apple-darwin,aarch64-apple-darwin,x86_64-unknown-linux-musl,aarch64-unknown-linux-musl
 
       - name: Download Windows host

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -41,6 +41,43 @@ def run(*args: str, env: dict[str, str] | None = None, check: bool = True) -> No
     subprocess.run(args, cwd=ROOT, env=env, check=check)
 
 
+def rust_host_target() -> str:
+    output = subprocess.check_output(["rustc", "-vV"], text=True)
+    for line in output.splitlines():
+        if line.startswith("host: "):
+            return line.removeprefix("host: ")
+    raise SystemExit("Could not determine the Rust host target")
+
+
+def find_llvm_strip() -> Path:
+    executable = shutil.which("llvm-strip")
+    if executable:
+        return Path(executable)
+
+    sysroot = Path(subprocess.check_output(["rustc", "--print", "sysroot"], text=True).strip())
+    executable = sysroot / "lib" / "rustlib" / rust_host_target() / "bin" / "llvm-strip"
+    if executable.is_file():
+        return executable
+
+    raise SystemExit(
+        "llvm-strip was not found; install it with "
+        "`rustup component add llvm-tools-preview`"
+    )
+
+
+def strip_linux_host(target_name: str) -> None:
+    if not target_name.endswith("musl"):
+        return
+
+    path = ROOT / "platform" / "targets" / target_name / "libhost.a"
+    before = path.stat().st_size
+    # ELF's strip-unneeded mode retains every symbol referenced by a
+    # relocation while dropping debug data and unused symbols.
+    run(str(find_llvm_strip()), "--strip-unneeded", str(path))
+    after = path.stat().st_size
+    print(f"Stripped {target_name} libhost.a: {before} -> {after} bytes")
+
+
 def detect_native_target() -> str:
     system = platform.system()
     machine = platform.machine().lower()
@@ -114,6 +151,7 @@ def build_unix_target(target_name: str, *, native: bool = False) -> None:
     qualifier = "native" if native else rust_target
     print(f"Building for {target_name} ({qualifier})...")
     copy_unix_host(target_name, rust_target, native=native)
+    strip_linux_host(target_name)
 
 
 def find_windows_sdk_lib_dir() -> Path:

--- a/scripts/bundle.py
+++ b/scripts/bundle.py
@@ -10,6 +10,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 PLATFORM_DIR = ROOT / "platform"
 LIBRARY_EXTENSIONS = {".a", ".o", ".lib", ".obj"}
+MAX_PLATFORM_BYTES = 100 * 1024 * 1024
 
 
 def relative_platform_path(path: Path) -> str:
@@ -37,6 +38,14 @@ def main() -> None:
         *(relative_platform_path(path) for path in roc_files),
         *(relative_platform_path(path) for path in library_files),
     ]
+    license_source = ROOT / "THIRD_PARTY_LICENSES.md"
+    unpacked_size = sum(path.stat().st_size for path in (*roc_files, *library_files))
+    unpacked_size += license_source.stat().st_size
+    if unpacked_size > MAX_PLATFORM_BYTES:
+        raise SystemExit(
+            "Platform inputs exceed Roc's default 100 MiB transitive dependency limit: "
+            f"{unpacked_size} bytes"
+        )
 
     print(
         f"Bundling {len(roc_files)} .roc files and "
@@ -47,8 +56,10 @@ def main() -> None:
         print(f"  {path}")
     print("  THIRD_PARTY_LICENSES.md\n", flush=True)
 
+    print(f"Unpacked platform size: {unpacked_size} bytes\n")
+
     license_target = PLATFORM_DIR / "THIRD_PARTY_LICENSES.md"
-    shutil.copy2(ROOT / "THIRD_PARTY_LICENSES.md", license_target)
+    shutil.copy2(license_source, license_target)
     try:
         subprocess.run(
             [


### PR DESCRIPTION
## Summary

- strip debug data and relocation-unneeded symbols from x64musl and arm64musl libhost.a files
- install llvm-tools-preview in CI and release jobs that build Linux hosts
- fail bundling before publication if unpacked platform inputs exceed the Roc default 100 MiB dependency limit

macOS and Windows archives are unchanged. Only the oversized Linux hosts need trimming, and avoiding Mach-O rewriting preserves Roc linker compatibility.

## Size impact

- x64musl libhost.a: 27.0 MB to 9.1 MB
- arm64musl libhost.a: 28.3 MB to 9.1 MB
- projected complete platform: 101.4 MiB to approximately 65.9 MiB

## Validation

- rebuilt and linked every example for x64musl using the stripped archive
- Python syntax checks passed
- workflow YAML parsing passed
- git diff --check passed