### PR TITLE
`Json.ParseErr` -> `InvalidJson(Str)`

### DIFF
--- a/platform/Locale.roc
+++ b/platform/Locale.roc
@@ -308,7 +308,7 @@ expect {
 
 ## Generic parsers validate encoded locale strings.
 expect {
-	decoded : Try(Locale, Json.ParseErr)
+	decoded : Try(Locale, [InvalidJson(Str)])
 	decoded = Json.parse("\"zh-Hant-TW\"")
 
 	match decoded {
@@ -318,7 +318,7 @@ expect {
 }
 
 expect {
-	decoded : Try(Locale, Json.ParseErr)
+	decoded : Try(Locale, [InvalidJson(Str)])
 	decoded = Json.parse("\"en_US\"")
 	decoded == Err(Json.invalid_json)
 }

--- a/platform/Url.roc
+++ b/platform/Url.roc
@@ -1375,7 +1375,7 @@ expect {
 
 ## Generic parsers validate and canonicalize encoded URL strings.
 expect {
-	decoded : Try(Url, Json.ParseErr)
+	decoded : Try(Url, [InvalidJson(Str)])
 	decoded = Json.parse("\"HTTPS://EXAMPLE.COM:443/a\"")
 
 	match decoded {
@@ -1385,7 +1385,7 @@ expect {
 }
 
 expect {
-	decoded : Try(Url, Json.ParseErr)
+	decoded : Try(Url, [InvalidJson(Str)])
 	decoded = Json.parse("\"not a url\"")
 	decoded == Err(Json.invalid_json)
 }


### PR DESCRIPTION
New JSON error type from compiler version `59bf05bf`.