### PR TITLE
Test all examples with Valgrind in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,3 +147,25 @@ jobs:
       - name: Run native spec cases
         shell: bash
         run: ./scripts/test.py --operation run --target "${{ matrix.target }}" --artifact-dir dist/example-binaries
+
+  valgrind-examples:
+    name: run examples with Valgrind (x64musl)
+    needs: [rust-version, build-examples]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install "${{ needs.rust-version.outputs.version }}" --profile minimal
+          rustup default "${{ needs.rust-version.outputs.version }}"
+      - name: Install Valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes valgrind
+      - name: Download x64musl example binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: basic-cli-example-binaries-x64musl
+          path: dist/example-binaries/x64musl
+      - name: Run native spec cases with Valgrind
+        run: ./scripts/test.py --operation run --target x64musl --artifact-dir dist/example-binaries --valgrind

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,14 +123,19 @@ jobs:
         include:
           - target: x64mac
             os: macos-26-intel
+            valgrind: false
           - target: arm64mac
             os: macos-26
+            valgrind: false
           - target: x64musl
             os: ubuntu-24.04
+            valgrind: true
           - target: arm64musl
             os: ubuntu-24.04-arm
+            valgrind: false
           - target: x64win
             os: windows-2025
+            valgrind: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -139,33 +144,21 @@ jobs:
         run: |
           rustup toolchain install "${{ needs.rust-version.outputs.version }}" --profile minimal
           rustup default "${{ needs.rust-version.outputs.version }}"
+      - name: Install Valgrind
+        if: matrix.valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes valgrind
       - name: Download native example binaries
         uses: actions/download-artifact@v8
         with:
           name: basic-cli-example-binaries-${{ matrix.target }}
           path: dist/example-binaries/${{ matrix.target }}
       - name: Run native spec cases
+        if: matrix.valgrind == false
         shell: bash
         run: ./scripts/test.py --operation run --target "${{ matrix.target }}" --artifact-dir dist/example-binaries
-
-  valgrind-examples:
-    name: run examples with Valgrind (x64musl)
-    needs: [rust-version, build-examples]
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install Rust toolchain
-        run: |
-          rustup toolchain install "${{ needs.rust-version.outputs.version }}" --profile minimal
-          rustup default "${{ needs.rust-version.outputs.version }}"
-      - name: Install Valgrind
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes valgrind
-      - name: Download x64musl example binaries
-        uses: actions/download-artifact@v8
-        with:
-          name: basic-cli-example-binaries-x64musl
-          path: dist/example-binaries/x64musl
       - name: Run native spec cases with Valgrind
-        run: ./scripts/test.py --operation run --target x64musl --artifact-dir dist/example-binaries --valgrind
+        if: matrix.valgrind
+        shell: bash
+        run: ./scripts/test.py --operation run --target "${{ matrix.target }}" --artifact-dir dist/example-binaries --valgrind

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,13 @@ The operations can also be run independently:
 ./scripts/test.py --operation run --target x64musl --artifact-dir dist/example-binaries
 ```
 
+On Linux, run those native artifacts under Valgrind with the same cases and
+output assertions used by CI:
+
+```sh
+./scripts/test.py --operation run --target x64musl --artifact-dir dist/example-binaries --valgrind
+```
+
 For faster local iterations when the platform host is already built:
 
 ```sh

--- a/ci/valgrind.supp
+++ b/ci/valgrind.supp
@@ -1,0 +1,7 @@
+# Statically linked x64musl binaries use musl's mallocng allocator directly.
+# Ignore its encoded-metadata check while retaining reports from every caller.
+{
+   musl-mallocng-enframe-uninitialised
+   Memcheck:Cond
+   fun:enframe
+}

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -34,6 +34,16 @@ ROOT = Path(__file__).resolve().parents[1]
 SPEC_PATH = ROOT / "scripts" / "test_spec.json"
 STAGES = ("fmt", "check", "test", "build", "run")
 DEFAULT_ARTIFACT_DIR = ROOT / "dist" / "example-binaries"
+VALGRIND_ARGS = (
+    "valgrind",
+    "--error-exitcode=99",
+    "--leak-check=full",
+    "--show-leak-kinds=all",
+    "--errors-for-leak-kinds=all",
+    "--track-origins=yes",
+    "--realloc-zero-bytes-frees=no",
+    f"--suppressions={ROOT / 'ci' / 'valgrind.supp'}",
+)
 
 
 def declared_targets() -> tuple[str, ...]:
@@ -358,18 +368,23 @@ def case_enabled(case: dict[str, object]) -> bool:
     return enabled
 
 
-def run_binary(app: dict[str, object], binary: Path, run_spec: dict[str, object]) -> None:
+def run_binary(
+    app: dict[str, object], binary: Path, run_spec: dict[str, object], *,
+    valgrind: bool,
+) -> None:
     source = ROOT / str(app["path"])
     case_name = str(run_spec["name"])
     print(f"\n--- {app['path']} [{case_name}] ---")
     args = [str(binary), *(expand(str(value), source) for value in run_spec.get("args", []))]
+    if valgrind:
+        args = [*VALGRIND_ARGS, *args]
     temporary_cwd = tempfile.TemporaryDirectory(prefix="basic-cli-case-") if run_spec.get("temp_cwd") else None
     cwd = Path(temporary_cwd.name) if temporary_cwd else Path(expand(str(run_spec.get("cwd", "{root}")), source))
     if "stdin_hex" in run_spec:
         stdin = bytes.fromhex(str(run_spec["stdin_hex"]))
     else:
         stdin = str(run_spec.get("stdin", "")).encode()
-    timeout = float(run_spec.get("timeout", 7))
+    timeout = float(run_spec.get("timeout", 7)) * (4 if valgrind else 1)
     fixtures = run_spec.get("fixtures", [])
     fixture_targets: list[Path] = []
     for fixture in fixtures:
@@ -406,7 +421,7 @@ def run_binary(app: dict[str, object], binary: Path, run_spec: dict[str, object]
 
 def run_stage(
     stage: str, defaults: dict[str, bool], apps: list[dict[str, object]],
-    binaries: dict[str, Path], build_dir: Path, target: str,
+    binaries: dict[str, Path], build_dir: Path, target: str, *, valgrind: bool = False,
 ) -> None:
     print(f"\n=== {stage.upper()} ===")
     for app in apps:
@@ -437,7 +452,7 @@ def run_stage(
                 raise SystemExit(f"{path}: run is enabled but build is disabled")
             for run_spec in run_cases(app):
                 if case_enabled(run_spec):
-                    run_binary(app, binary, run_spec)
+                    run_binary(app, binary, run_spec, valgrind=valgrind)
                 else:
                     print(f"SKIP run case: {path} [{run_spec['name']}]")
 
@@ -508,7 +523,7 @@ def load_artifact_binaries(target: str, artifact_dir: Path,
     return binaries
 
 
-def run_artifact_cases(target: str, artifact_dir: Path) -> None:
+def run_artifact_cases(target: str, artifact_dir: Path, *, valgrind: bool) -> None:
     defaults, apps = load_spec()
     binaries = load_artifact_binaries(target, artifact_dir, defaults, apps)
     if any(
@@ -517,10 +532,13 @@ def run_artifact_cases(target: str, artifact_dir: Path) -> None:
         for app in apps
     ):
         command("cargo", "build", "--locked", "--release", cwd=ROOT / "ci" / "rust_http_server")
-    run_stage("run", defaults, apps, binaries, artifact_dir, target)
+    run_stage("run", defaults, apps, binaries, artifact_dir, target, valgrind=valgrind)
 
 
-def run_suite(bundle_url: str, operations: set[str], target: str, artifact_dir: Path) -> None:
+def run_suite(
+    bundle_url: str, operations: set[str], target: str, artifact_dir: Path, *,
+    valgrind: bool,
+) -> None:
     defaults, apps = load_spec()
     sources = [ROOT / str(app["path"]) for app in apps]
     backups = {path: path.read_bytes() for path in sources}
@@ -548,7 +566,7 @@ def run_suite(bundle_url: str, operations: set[str], target: str, artifact_dir: 
         if "run" in operations:
             if not binaries:
                 binaries = load_artifact_binaries(target, artifact_dir, defaults, apps)
-            run_stage("run", defaults, apps, binaries, artifact_dir, target)
+            run_stage("run", defaults, apps, binaries, artifact_dir, target, valgrind=valgrind)
     finally:
         for path, contents in backups.items():
             path.write_bytes(contents)
@@ -573,15 +591,23 @@ def main() -> None:
     )
     parser.add_argument("--target", choices=declared_targets())
     parser.add_argument("--artifact-dir", type=Path, default=DEFAULT_ARTIFACT_DIR)
+    parser.add_argument(
+        "--valgrind", action="store_true",
+        help="run native example cases under Valgrind and fail on memory errors or leaks",
+    )
     args = parser.parse_args()
     if args.bundle_path and args.bundle_url:
         parser.error("--bundle-path and --bundle-url are mutually exclusive")
     target = args.target or detect_native_target()
     artifact_dir = args.artifact_dir.resolve()
+    if args.valgrind and shutil.which("valgrind") is None:
+        parser.error("--valgrind requires 'valgrind' on PATH")
+    if args.valgrind and args.operation not in ("all", "run"):
+        parser.error("--valgrind requires an operation that runs example cases")
     if args.operation == "run":
         if target != detect_native_target():
             raise SystemExit(f"Cannot run {target} artifacts on native target {detect_native_target()}")
-        run_artifact_cases(target, artifact_dir)
+        run_artifact_cases(target, artifact_dir, valgrind=args.valgrind)
         print("\n=== All native run cases passed! ===")
         return
 
@@ -604,7 +630,7 @@ def main() -> None:
     try:
         if args.bundle_url:
             print(f"\n=== Using provided bundle ===\nBundle: {args.bundle_url}")
-            run_suite(args.bundle_url, operations, target, artifact_dir)
+            run_suite(args.bundle_url, operations, target, artifact_dir, valgrind=args.valgrind)
         else:
             bundle = args.bundle_path
             if bundle is None:
@@ -617,7 +643,7 @@ def main() -> None:
                 raise SystemExit(f"Bundle does not exist: {bundle}")
             with BundleServer(bundle) as bundle_url:
                 print(f"Bundle: {bundle_url}")
-                run_suite(bundle_url, operations, target, artifact_dir)
+                run_suite(bundle_url, operations, target, artifact_dir, valgrind=args.valgrind)
     finally:
         if generated_bundle is not None:
             generated_bundle.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- add a Valgrind mode to the spec-driven example runner
- fail on reported memory errors and leaks while preserving each case's expected exit code and output assertions
- run the existing x64musl matrix entry under Valgrind while keeping arm64 Linux, macOS, and Windows as normal executions
- suppress the known musl mallocng encoded-metadata check without suppressing callers

Closes #192

## Testing

- ./scripts/test.py --operation build --target x64musl --artifact-dir /tmp/basic-cli-192-artifacts
- ./scripts/test.py --operation run --target x64musl --artifact-dir /tmp/basic-cli-192-artifacts --valgrind
- ./scripts/test.py --operation run --target x64musl --artifact-dir /tmp/basic-cli-192-artifacts
- parsed scripts/test.py and .github/workflows/ci.yml
- git diff --check