### PR TITLE
Update Rust to 1.97.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "roc_host"
 version = "0.21.0-rc4"
 authors = ["The Roc Contributors"]
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.97"
 license = "UPL-1.0"
 repository = "https://github.com/roc-lang/basic-cli"
 

--- a/platform/OsStr.roc
+++ b/platform/OsStr.roc
@@ -129,24 +129,24 @@ utf8_to_utf16 = |remaining, out|
 		[byte, .. as rest] if byte < 0x80 =>
 			utf8_to_utf16(rest, out.append(U8.to_u16(byte)))
 		[byte1, byte2, .. as rest] if byte1 < 0xE0 => {
-			top = U32.shift_left_by(U8.to_u32(U8.bitwise_and(byte1, 0x1F)), 6)
+			top = U32.shl_wrap(U8.to_u32(U8.bitwise_and(byte1, 0x1F)), 6)
 			bottom = U8.to_u32(U8.bitwise_and(byte2, 0x3F))
 			utf8_to_utf16(rest, out.append(U32.to_u16_wrap(U32.bitwise_or(top, bottom))))
 		}
 		[byte1, byte2, byte3, .. as rest] if byte1 < 0xF0 => {
-			top = U32.shift_left_by(U8.to_u32(U8.bitwise_and(byte1, 0x0F)), 12)
-			middle = U32.shift_left_by(U8.to_u32(U8.bitwise_and(byte2, 0x3F)), 6)
+			top = U32.shl_wrap(U8.to_u32(U8.bitwise_and(byte1, 0x0F)), 12)
+			middle = U32.shl_wrap(U8.to_u32(U8.bitwise_and(byte2, 0x3F)), 6)
 			bottom = U8.to_u32(U8.bitwise_and(byte3, 0x3F))
 			code_point = U32.bitwise_or(U32.bitwise_or(top, middle), bottom)
 			utf8_to_utf16(rest, out.append(U32.to_u16_wrap(code_point)))
 		}
 		[byte1, byte2, byte3, byte4, .. as rest] => {
-			top = U32.shift_left_by(U8.to_u32(U8.bitwise_and(byte1, 0x07)), 18)
-			middle1 = U32.shift_left_by(U8.to_u32(U8.bitwise_and(byte2, 0x3F)), 12)
-			middle2 = U32.shift_left_by(U8.to_u32(U8.bitwise_and(byte3, 0x3F)), 6)
+			top = U32.shl_wrap(U8.to_u32(U8.bitwise_and(byte1, 0x07)), 18)
+			middle1 = U32.shl_wrap(U8.to_u32(U8.bitwise_and(byte2, 0x3F)), 12)
+			middle2 = U32.shl_wrap(U8.to_u32(U8.bitwise_and(byte3, 0x3F)), 6)
 			bottom = U8.to_u32(U8.bitwise_and(byte4, 0x3F))
 			code_point = U32.bitwise_or(U32.bitwise_or(U32.bitwise_or(top, middle1), middle2), bottom)
-			high = U32.to_u16_wrap(0xD800 + U32.shift_right_by(code_point - 0x10000, 10))
+			high = U32.to_u16_wrap(0xD800 + U32.shr_wrap(code_point - 0x10000, 10))
 			low = U32.to_u16_wrap(0xDC00 + U32.bitwise_and(code_point - 0x10000, 0x3FF))
 			utf8_to_utf16(rest, out.append(high).append(low))
 		}
@@ -171,7 +171,7 @@ utf16_to_utf8 = |remaining, out, index|
 	match remaining {
 		[] => Ok(out)
 		[high, low, .. as rest] if is_high_surrogate(high) and is_low_surrogate(low) => {
-			high_bits = U32.shift_left_by(U16.to_u32(high) - 0xD800, 10)
+			high_bits = U32.shl_wrap(U16.to_u32(high) - 0xD800, 10)
 			low_bits = U16.to_u32(low) - 0xDC00
 			code_point = 0x10000 + high_bits + low_bits
 			utf16_to_utf8(rest, append_code_point_utf8(out, code_point), index + 2)
@@ -189,7 +189,7 @@ utf16_to_utf8_lossy_help = |remaining, out|
 	match remaining {
 		[] => out
 		[high, low, .. as rest] if is_high_surrogate(high) and is_low_surrogate(low) => {
-			high_bits = U32.shift_left_by(U16.to_u32(high) - 0xD800, 10)
+			high_bits = U32.shl_wrap(U16.to_u32(high) - 0xD800, 10)
 			low_bits = U16.to_u32(low) - 0xDC00
 			code_point = 0x10000 + high_bits + low_bits
 			utf16_to_utf8_lossy_help(rest, append_code_point_utf8(out, code_point))
@@ -205,16 +205,16 @@ append_code_point_utf8 = |out, code_point|
 	if code_point < 0x80 {
 		out.append(U32.to_u8_wrap(code_point))
 	} else if code_point < 0x800 {
-		out.append(U32.to_u8_wrap(0xC0 + U32.shift_right_by(code_point, 6)))
+		out.append(U32.to_u8_wrap(0xC0 + U32.shr_wrap(code_point, 6)))
 			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(code_point, 0x3F)))
 	} else if code_point < 0x10000 {
-		out.append(U32.to_u8_wrap(0xE0 + U32.shift_right_by(code_point, 12)))
-			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(U32.shift_right_by(code_point, 6), 0x3F)))
+		out.append(U32.to_u8_wrap(0xE0 + U32.shr_wrap(code_point, 12)))
+			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(U32.shr_wrap(code_point, 6), 0x3F)))
 			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(code_point, 0x3F)))
 	} else {
-		out.append(U32.to_u8_wrap(0xF0 + U32.shift_right_by(code_point, 18)))
-			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(U32.shift_right_by(code_point, 12), 0x3F)))
-			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(U32.shift_right_by(code_point, 6), 0x3F)))
+		out.append(U32.to_u8_wrap(0xF0 + U32.shr_wrap(code_point, 18)))
+			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(U32.shr_wrap(code_point, 12), 0x3F)))
+			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(U32.shr_wrap(code_point, 6), 0x3F)))
 			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(code_point, 0x3F)))
 	}
 

--- a/platform/Path.roc
+++ b/platform/Path.roc
@@ -379,7 +379,7 @@ utf8_to_utf16 = |remaining, out|
 			utf8_to_utf16(rest, out.append(U8.to_u16(byte)))
 
 		[byte1, byte2, .. as rest] if byte1 < 0xE0 => {
-			top = U32.shift_left_by(U8.to_u32(U8.bitwise_and(byte1, 0x1F)), 6)
+			top = U32.shl_wrap(U8.to_u32(U8.bitwise_and(byte1, 0x1F)), 6)
 			bottom = U8.to_u32(U8.bitwise_and(byte2, 0x3F))
 			code_point = U32.bitwise_or(top, bottom)
 
@@ -387,8 +387,8 @@ utf8_to_utf16 = |remaining, out|
 		}
 
 		[byte1, byte2, byte3, .. as rest] if byte1 < 0xF0 => {
-			top = U32.shift_left_by(U8.to_u32(U8.bitwise_and(byte1, 0x0F)), 12)
-			middle = U32.shift_left_by(U8.to_u32(U8.bitwise_and(byte2, 0x3F)), 6)
+			top = U32.shl_wrap(U8.to_u32(U8.bitwise_and(byte1, 0x0F)), 12)
+			middle = U32.shl_wrap(U8.to_u32(U8.bitwise_and(byte2, 0x3F)), 6)
 			bottom = U8.to_u32(U8.bitwise_and(byte3, 0x3F))
 			code_point = U32.bitwise_or(U32.bitwise_or(top, middle), bottom)
 
@@ -396,14 +396,14 @@ utf8_to_utf16 = |remaining, out|
 		}
 
 		[byte1, byte2, byte3, byte4, .. as rest] => {
-			top = U32.shift_left_by(U8.to_u32(U8.bitwise_and(byte1, 0x07)), 18)
-			middle1 = U32.shift_left_by(U8.to_u32(U8.bitwise_and(byte2, 0x3F)), 12)
-			middle2 = U32.shift_left_by(U8.to_u32(U8.bitwise_and(byte3, 0x3F)), 6)
+			top = U32.shl_wrap(U8.to_u32(U8.bitwise_and(byte1, 0x07)), 18)
+			middle1 = U32.shl_wrap(U8.to_u32(U8.bitwise_and(byte2, 0x3F)), 12)
+			middle2 = U32.shl_wrap(U8.to_u32(U8.bitwise_and(byte3, 0x3F)), 6)
 			bottom = U8.to_u32(U8.bitwise_and(byte4, 0x3F))
 			upper = U32.bitwise_or(U32.bitwise_or(top, middle1), middle2)
 			code_point = U32.bitwise_or(upper, bottom)
 
-			high = U32.to_u16_wrap(0xD800 + U32.shift_right_by(code_point - 0x10000, 10))
+			high = U32.to_u16_wrap(0xD800 + U32.shr_wrap(code_point - 0x10000, 10))
 			low = U32.to_u16_wrap(0xDC00 + U32.bitwise_and(code_point - 0x10000, 0x3FF))
 
 			utf8_to_utf16(rest, out.append(high).append(low))
@@ -432,7 +432,7 @@ utf16_to_utf8 = |remaining, out, index|
 		[] => Ok(out)
 
 		[high, low, .. as rest] if is_high_surrogate(high) and is_low_surrogate(low) => {
-			high_bits = U32.shift_left_by(U16.to_u32(high) - 0xD800, 10)
+			high_bits = U32.shl_wrap(U16.to_u32(high) - 0xD800, 10)
 			low_bits = U16.to_u32(low) - 0xDC00
 			code_point = 0x10000 + high_bits + low_bits
 
@@ -454,7 +454,7 @@ utf16_to_utf8_lossy_help = |remaining, out|
 		[] => out
 
 		[high, low, .. as rest] if is_high_surrogate(high) and is_low_surrogate(low) => {
-			high_bits = U32.shift_left_by(U16.to_u32(high) - 0xD800, 10)
+			high_bits = U32.shl_wrap(U16.to_u32(high) - 0xD800, 10)
 			low_bits = U16.to_u32(low) - 0xDC00
 			code_point = 0x10000 + high_bits + low_bits
 
@@ -473,16 +473,16 @@ append_code_point_utf8 = |out, code_point|
 	if code_point < 0x80 {
 		out.append(U32.to_u8_wrap(code_point))
 	} else if code_point < 0x800 {
-		out.append(U32.to_u8_wrap(0xC0 + U32.shift_right_by(code_point, 6)))
+		out.append(U32.to_u8_wrap(0xC0 + U32.shr_wrap(code_point, 6)))
 			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(code_point, 0x3F)))
 	} else if code_point < 0x10000 {
-		out.append(U32.to_u8_wrap(0xE0 + U32.shift_right_by(code_point, 12)))
-			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(U32.shift_right_by(code_point, 6), 0x3F)))
+		out.append(U32.to_u8_wrap(0xE0 + U32.shr_wrap(code_point, 12)))
+			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(U32.shr_wrap(code_point, 6), 0x3F)))
 			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(code_point, 0x3F)))
 	} else {
-		out.append(U32.to_u8_wrap(0xF0 + U32.shift_right_by(code_point, 18)))
-			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(U32.shift_right_by(code_point, 12), 0x3F)))
-			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(U32.shift_right_by(code_point, 6), 0x3F)))
+		out.append(U32.to_u8_wrap(0xF0 + U32.shr_wrap(code_point, 18)))
+			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(U32.shr_wrap(code_point, 12), 0x3F)))
+			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(U32.shr_wrap(code_point, 6), 0x3F)))
 			.append(U32.to_u8_wrap(0x80 + U32.bitwise_and(code_point, 0x3F)))
 	}
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,7 +5,7 @@
 #     a) Find the latest nightly release that matches RUST_VERSION here: https://github.com/oxalica/rust-overlay/tree/master/manifests/nightly/2024
 #     b) update `channel = "nightly-OLD_DATE"` below
 
-channel = "1.83.0" # check ^^^ when changing this
+channel = "1.97.1" # check ^^^ when changing this
 components = ["rust-analyzer"]
 #
 # channel = "nightly-2024-04-28" # 1.79.0 nightly to be able to use unstable features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1568,10 +1568,7 @@ fn file_permission_bit(
     Ok(metadata.permissions().mode() & bit != 0)
 }
 
-fn file_is_executable(
-    path: UnixBytesOrUtf8OrWindowsU16s,
-    roc_host: &RocHost,
-) -> io::Result<bool> {
+fn file_is_executable(path: UnixBytesOrUtf8OrWindowsU16s, roc_host: &RocHost) -> io::Result<bool> {
     #[cfg(unix)]
     {
         file_permission_bit(path, roc_host, 0o111)
@@ -1600,10 +1597,7 @@ fn file_is_executable(
     }
 }
 
-fn file_is_readable(
-    path: UnixBytesOrUtf8OrWindowsU16s,
-    roc_host: &RocHost,
-) -> io::Result<bool> {
+fn file_is_readable(path: UnixBytesOrUtf8OrWindowsU16s, roc_host: &RocHost) -> io::Result<bool> {
     #[cfg(unix)]
     {
         file_permission_bit(path, roc_host, 0o400)
@@ -1624,10 +1618,7 @@ fn file_is_readable(
     }
 }
 
-fn file_is_writable(
-    path: UnixBytesOrUtf8OrWindowsU16s,
-    roc_host: &RocHost,
-) -> io::Result<bool> {
+fn file_is_writable(path: UnixBytesOrUtf8OrWindowsU16s, roc_host: &RocHost) -> io::Result<bool> {
     #[cfg(unix)]
     {
         file_permission_bit(path, roc_host, 0o200)


### PR DESCRIPTION
## Summary

- pin the repository toolchain to Rust 1.97.1, the latest stable point release
- raise the declared minimum Rust version from 1.83 to 1.97
- apply the formatting produced by rustfmt 1.97.1

Release announcement: https://blog.rust-lang.org/2026/07/16/Rust-1.97.1/

## Temporary stack

This branch temporarily includes commit `6f3703d` from #458 so the Rust upgrade can be validated with the current Roc compiler. Because #458 comes from a fork, GitHub cannot use its head branch directly as this PR's base. Once #458 merges, this branch can be rebased onto `main`, leaving only the Rust upgrade diff.

## Testing

- `cargo fmt --check`
- `cargo test --locked --all-targets` (8 passed)
- `cargo build --locked --release`
- `python3 -m unittest scripts/test_check_release_version.py` (3 passed)
- `./scripts/test.py --operation validate`
  - rebuilt the x64 musl host with Rust 1.97.1
  - platform tests: 183 passed
  - all example formatting, checks, and tests passed