### PR TITLE
Add Sleep.seconds!

### DIFF
--- a/examples/time.roc
+++ b/examples/time.roc
@@ -14,8 +14,7 @@ main! = |_args| {
 
 	Stdout.line!("Started at ${Utc.to_iso_8601(start)}")?
 
-	# 1000 ms = 1 second
-	Sleep.millis!(1000)
+	Sleep.seconds!(1)
 
 	finish : U128
 	finish = Utc.now!()

--- a/platform/Sleep.roc
+++ b/platform/Sleep.roc
@@ -1,9 +1,44 @@
 import Host
 
+## Convert a duration in seconds into whole milliseconds for the host.
+##
+## `to_u64_try` rejects negative, `NaN`, and too-large values alike, so a
+## positive value here is one that overflowed the millisecond range.
+millis_from_seconds : F64 -> U64
+millis_from_seconds = |seconds|
+	match F64.to_u64_try(seconds * 1000) {
+		Ok(milliseconds) => milliseconds
+		Err(OutOfRange) => if seconds > 0 U64.highest else 0
+	}
+
 ## Pause the current process for a requested duration.
 Sleep :: [].{
 
 	## Sleep for the specified number of milliseconds.
 	millis! : U64 => {}
 	millis! = |milliseconds| Host.sleep_millis!(milliseconds)
+
+	## Sleep for the specified number of seconds.
+	##
+	## The duration is truncated to whole milliseconds, so `Sleep.seconds!(1.5)`
+	## sleeps for 1500 ms. Negative and `NaN` durations return immediately, and
+	## durations past [U64.highest] milliseconds saturate there.
+	seconds! : F64 => {}
+	seconds! = |seconds| Host.sleep_millis!(millis_from_seconds(seconds))
 }
+
+expect millis_from_seconds(1) == 1000
+expect millis_from_seconds(1.5) == 1500
+expect millis_from_seconds(0.25) == 250
+expect millis_from_seconds(0) == 0
+
+# Sub-millisecond durations truncate toward zero rather than rounding up.
+expect millis_from_seconds(0.0004) == 0
+
+# Negative and NaN durations return immediately instead of crashing.
+expect millis_from_seconds(-5) == 0
+expect millis_from_seconds(F64.nan) == 0
+
+# Durations beyond the host's millisecond counter saturate.
+expect millis_from_seconds(F64.infinity) == U64.highest
+expect millis_from_seconds(1.0e30) == U64.highest


### PR DESCRIPTION
Adds `Sleep.seconds!`, closes #409.

Discussed on [Zulip](https://roc.zulipchat.com/#narrow/channel/316715-contributing/topic/basic-cli.20good.20first.20issues/near/612604372) — @Anton-4 preferred `F64` over `U64` so that one function covers whole and fractional durations without having to switch back to `millis!`.

## Implementation

`seconds!` converts to milliseconds and delegates to the existing `Host.sleep_millis!`, so there are no host or glue changes.

The conversion is the only subtle part, so it lives in a pure top-level helper, `millis_from_seconds`, which keeps it unit-testable. `F64.round_to_u64` crashes on negative, `NaN`, infinite, and out-of-range values, which isn't acceptable for a signature with no error channel. `F64.to_u64_try` rejects exactly that set, so the helper separates the cases by sign: a positive value reaching the `Err` branch can only be one that overflowed the millisecond range.

## Edge-case behavior

This wasn't part of the Zulip discussion, so flagging it explicitly for review:

| Input | Behavior |
| --- | --- |
| `1.5` | sleeps 1500 ms — fractional part truncated to whole ms |
| `0.0004` | truncates to 0 ms rather than rounding up |
| `0` | returns immediately |
| negative | returns immediately |
| `NaN` | returns immediately |
| `inf`, or beyond `U64.highest` ms | saturates at `U64.highest` ms |

Returning immediately on negative and `NaN` follows Go's `time.Sleep`. Happy to change either behavior if you'd prefer something different.

## Testing

Nine `expect` blocks in `platform/Sleep.roc` cover `millis_from_seconds` across all three branches — the ordinary conversion, the negative/`NaN` case, and saturation. Each was verified to fail when its expected value is altered, so they aren't vacuously green.

Full `./scripts/test.py` passes — host build plus all examples.

The effectful wrapper was also measured against a local build of the platform before being reduced to a one-liner: `1.5 → 1500 ms`, `0.25 → 253 ms`, `0 → 0 ms`, `-5 → 0 ms`, `NaN → 0 ms`. The saturating branch can't be exercised at runtime, since it sleeps for roughly 584 million years; it is covered by the `expect` on `millis_from_seconds` instead.

`examples/time.roc` now uses `Sleep.seconds!(1)` in place of `Sleep.millis!(1000)` and its `# 1000 ms = 1 second` comment, which is the ergonomic problem the issue describes. Its `one-second-sleep` case asserts output shape rather than the duration value, so `scripts/test_spec.json` is unchanged.
