### PR TITLE
Add Path.replace_utf8!

### DIFF
--- a/examples/file-replace.roc
+++ b/examples/file-replace.roc
@@ -1,0 +1,27 @@
+## Replace every occurrence of a substring in a UTF-8 file in place.
+app [main!] { pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.21.0-rc4/FvCh4vdqm3nBY6DWEfZ8RuGCVfjuMY43HA8KSNk9qVDn.tar.zst" }
+
+import pf.OsStr
+import pf.Stdout
+import pf.Path
+
+main! : List(OsStr) => Try({}, _)
+main! = |_args| {
+
+	file : Path
+	file = "greeting.txt"
+
+	file.write_utf8!("Hello, World! Hello, Roc!")?
+
+	# Replaces both occurrences of "Hello", not just the first.
+	file.replace_utf8!("Hello", "Goodbye")?
+
+	contents = file.read_utf8!()?
+
+	# Cleanup
+	file.delete!()?
+
+	Stdout.line!("After replacing: \"${contents}\"")?
+
+	Ok({})
+}

--- a/platform/Path.roc
+++ b/platform/Path.roc
@@ -107,6 +107,18 @@ Path := [
 	write_utf8! : Path, Str => Try({}, [PathErr(IOErr), ..])
 	write_utf8! = |path, content| map_file_result(Host.file_write_utf8!(to_raw(path), content))
 
+	## Replace every occurrence of `pattern` with `replacement` in the UTF-8 file
+	## at this path.
+	##
+	## This reads the whole file, substitutes, and writes it back, so it is not
+	## atomic: a failure mid-write can leave the file partially written, exactly
+	## as a bare [write_utf8!] would.
+	replace_utf8! : Path, Str, Str => Try({}, [PathErr(IOErr), ..])
+	replace_utf8! = |path, pattern, replacement| {
+		content = read_utf8!(path)?
+		write_utf8!(path, Str.replace_each(content, pattern, replacement))
+	}
+
 	## Delete a file at this path.
 	delete! : Path => Try({}, [PathErr(IOErr), ..])
 	delete! = |path| map_file_result(Host.file_delete!(to_raw(path)))

--- a/scripts/test_spec.json
+++ b/scripts/test_spec.json
@@ -149,6 +149,18 @@
       ]
     },
     {
+      "path": "examples/file-replace.roc",
+      "cases": [
+        {
+          "name": "happy",
+          "temp_cwd": true,
+          "contains": [
+            "After replacing: \"Goodbye, World! Goodbye, Roc!\""
+          ]
+        }
+      ]
+    },
+    {
       "path": "examples/file-size.roc",
       "cases": [
         {


### PR DESCRIPTION
Adds `Path.replace_utf8!`, closes #386.

Discussed on [Zulip](https://roc.zulipchat.com/#narrow/channel/316715-contributing/topic/Path.2Ereplace_utf8!.20(basic-cli.20.23386)) — @Anton-4 settled the four open questions and retitled the issue accordingly:

- **Location:** `Path.replace_utf8!` only. `File` is now just buffered readers, so whole-file operations stay on `Path`. Nothing added to `File`.
- **Scope:** the replace-all ("each") form only, mirroring `Str.replace_each`.
- **Argument name:** `pattern` rather than the builtin's `delimiter`, which reads oddly for file contents.
- **Atomicity:** kept as a plain read-modify-write composition, documented as non-atomic (see below).

## Implementation

```roc
replace_utf8! : Path, Str, Str => Try({}, [PathErr(IOErr), ..])
replace_utf8! = |path, pattern, replacement| {
    content = read_utf8!(path)?
    write_utf8!(path, Str.replace_each(content, pattern, replacement))
}
```

Pure Roc over the existing `read_utf8!` / `write_utf8!` and the `Str.replace_each` builtin, so there are no host or glue changes.

**Non-atomic, by decision.** This reads the whole file, substitutes, and writes it back, so a failure mid-write can leave the file partially written — exactly as a bare `write_utf8!` would. The doc comment states this. A safe temp-file-and-rename variant is a larger change that would also apply to `write_utf8!`, so it belongs in its own issue rather than being folded in here.

## Testing

`examples/file-replace.roc` demonstrates the API and doubles as the behavioral test: it writes `"Hello, World! Hello, Roc!"`, calls `replace_utf8!("Hello", "Goodbye")`, and reads it back. Its `test_spec.json` case asserts the exact result `After replacing: "Goodbye, World! Goodbye, Roc!"`, which proves the replace-*each* behavior — both occurrences change, not just the first.

The assertion was verified to fail when the expected string is altered, so it isn't vacuously green. Full `./scripts/test.py` passes — host build plus all examples across every target.

`replace_utf8!` is effectful, so there's no pure core to cover with `expect` blocks; the executed example is the proportionate coverage.
