### PR TITLE
Pin releases to the latest Roc nightly

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/configure-pages@v6
 
       - name: Install Roc
-        uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
+        uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427 # ratchet:roc-lang/setup-roc@v0.3.0
         with:
           version: nightly-new-compiler
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ concurrency:
   group: ${{ github.event_name == 'workflow_dispatch' && format('release-{0}', github.repository) || format('release-validate-{0}-{1}', github.repository, github.ref) }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
+# Release artifacts must be reproducible. Daily CI intentionally follows the
+# moving nightly channel and this pin is advanced after that toolchain is green.
+env:
+  ROC_NIGHTLY_TAG: nightly-2026-July-27-f4b3c60
+
 jobs:
   rust-version:
     name: read Rust version
@@ -111,9 +116,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install Roc
-        uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
+        uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427 # ratchet:roc-lang/setup-roc@v0.3.0
         with:
           version: nightly-new-compiler
+          nightly-tag: ${{ env.ROC_NIGHTLY_TAG }}
 
       - name: Install Zig
         uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f
@@ -211,9 +217,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Roc
-        uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
+        uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427 # ratchet:roc-lang/setup-roc@v0.3.0
         with:
           version: nightly-new-compiler
+          nightly-tag: ${{ env.ROC_NIGHTLY_TAG }}
 
       - name: Install Rust
         shell: bash
@@ -255,9 +262,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Roc
-        uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
+        uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427 # ratchet:roc-lang/setup-roc@v0.3.0
         with:
           version: nightly-new-compiler
+          nightly-tag: ${{ env.ROC_NIGHTLY_TAG }}
 
       - name: Create docs staging tree
         run: mkdir -p docs-site
@@ -402,9 +410,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install Roc
-        uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
+        uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427 # ratchet:roc-lang/setup-roc@v0.3.0
         with:
           version: nightly-new-compiler
+          nightly-tag: ${{ env.ROC_NIGHTLY_TAG }}
 
       - name: Download release metadata
         uses: actions/download-artifact@v8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,10 @@ For local work, use any recent `roc` on `PATH`, or download the latest archive
 for your operating system from the
 [`roc-lang/nightlies` releases](https://github.com/roc-lang/nightlies/releases/latest).
 
+Release artifacts use the exact nightly named by `ROC_NIGHTLY_TAG` in
+`.github/workflows/release.yml`. Advance that pin to a nightly that has passed
+the moving daily CI before dispatching a release.
+
 ## Code of Conduct
 
 We are committed to providing a friendly, safe, and welcoming environment for all. See the [Code of Conduct](https://github.com/roc-lang/roc/blob/main/CODE_OF_CONDUCT.md) for details.


### PR DESCRIPTION
## Summary

- update release and docs workflows to `setup-roc` v0.3.0
- pin release validation, bundles, tests, and docs to `nightly-2026-July-27-f4b3c60`
- document how to advance the release compiler after moving daily CI is green

Daily CI remains on the moving `nightly-new-compiler` channel so new Roc regressions are still detected. Pinning only the release workflow makes an approved release reproducible and prevents its compiler changing between PR validation and dispatch.

## Verification

- `python3 scripts/test.py`
- `python3 -m unittest scripts/test_check_release_version.py`
- `python3 scripts/check_release_version.py 0.21.0-rc4`
- `git diff --check`

The full local suite passed with `release-fast-f4b3c607`, the compiler in the pinned nightly. Canonical daily CI also passed against this nightly.