### PR TITLE
update bytes for dependebot security alert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ hyper-util = { version = "=0.1.12", default-features = false, features = ["clien
 hyper-rustls = { version = "=0.27.6", default-features = false, features = ["http1", "tls12", "webpki-tokio", "ring"] }
 http-body-util = "=0.1.3"
 tokio = { version = "=1.45.0", default-features = false, features = ["rt", "net", "time"] }
-bytes = "=1.10.1"
+bytes = "=1.12.1"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 sys-locale = "=0.3.2"

--- a/ci/rust_http_server/Cargo.lock
+++ b/ci/rust_http_server/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"

--- a/ci/rust_http_server/Cargo.toml
+++ b/ci/rust_http_server/Cargo.toml
@@ -11,6 +11,6 @@ hyper = { version = "=1.6.0", default-features = false, features = ["server", "h
 tokio = { version = "=1.45.0", default-features = false, features = ["macros", "rt", "rt-multi-thread"] }
 hyper-util = { version = "=0.1.12", features = ["tokio"] }
 http-body-util = "=0.1.3"
-bytes = "=1.10.1"
+bytes = "=1.12.1"
 
 [workspace]


### PR DESCRIPTION
basic-cli never actually triggered the vulnerable rust code path, so kind of a false positive.