### PR TITLE
Fix sqlite decoder inference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427 # ratchet:roc-lang/setup-roc@v0.3.0
         with:
           version: nightly-new-compiler
-          nightly-tag: nightly-2026-08-23-fb208ba
+          nightly-tag: nightly-2026-08-30-34e7489
       - name: Install Rust toolchain
         run: |
           rustup toolchain install "${{ needs.rust-version.outputs.version }}" --profile minimal --target x86_64-unknown-linux-musl --component llvm-tools-preview
@@ -58,7 +58,7 @@ jobs:
       - uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427 # ratchet:roc-lang/setup-roc@v0.3.0
         with:
           version: nightly-new-compiler
-          nightly-tag: nightly-2026-08-23-fb208ba
+          nightly-tag: nightly-2026-08-30-34e7489
       - name: Install Rust toolchain
         shell: bash
         run: |
@@ -103,7 +103,7 @@ jobs:
       - uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427 # ratchet:roc-lang/setup-roc@v0.3.0
         with:
           version: nightly-new-compiler
-          nightly-tag: nightly-2026-08-23-fb208ba
+          nightly-tag: nightly-2026-08-30-34e7489
       - name: Install Rust toolchain
         shell: bash
         run: |

--- a/platform/Sqlite.roc
+++ b/platform/Sqlite.roc
@@ -395,7 +395,7 @@ decode_rows! = |stmt, gen_decode| {
 }
 
 lookup_value! = |cols, stmt, name|
-	match cols.find_first_index(|x| x == name) {
+	match List.find_first_index(cols, |x| x == name) {
 		Ok(index) => sqlite_column_value!(stmt, index)
 		Err(NotFound) => Err(NoSuchField(name))
 	}
@@ -499,3 +499,20 @@ code_from_i64 = |code|
 		101 => Done
 		other => Unknown(other)
 	}
+
+## A row decoder written the way an application writes one, with a name of its
+## own. The compiler has to settle its type right here, before `query_many!`
+## ever gets to say what `cols` is. Each column asks about `cols` separately,
+## and since roc-lang/roc#10984 those questions no longer share an answer.
+##
+## The test is successful if this snippet compiles.
+expect {
+	_decode_row = |cols|
+		|stmt| {
+			id = Sqlite.i64("id")(cols)(stmt)?
+			task = Sqlite.str("task")(cols)(stmt)?
+			status = Sqlite.str("status")(cols)(stmt)?
+			Ok({ id, task, status })
+		}
+	Bool.True
+}

--- a/platform/Sqlite.roc
+++ b/platform/Sqlite.roc
@@ -500,10 +500,10 @@ code_from_i64 = |code|
 		other => Unknown(other)
 	}
 
-## A row decoder written the way an application writes one, with a name of its
-## own. The compiler has to settle its type right here, before `query_many!`
-## ever gets to say what `cols` is. Each column asks about `cols` separately,
-## and since roc-lang/roc#10984 those questions no longer share an answer.
+## A row decoder written the way an application writes one.
+## The compiler has to settle its type right here, before `query_many!`
+## ever gets to say what `cols` is. Each call infers the type of `cols` separately,
+## and since roc-lang/roc#10984 these types are no longer resolved together.
 ##
 ## The test is successful if this snippet compiles.
 expect {


### PR DESCRIPTION

The SQLite examples stop type-checking on any nightly from `nightly-2026-08-30-34e7489` onward.

```
── ✗ missing method ─ examples/sqlite-basic.roc:65:8
This is trying to dispatch a method named find_first_index on an unresolved
type variable, but unresolved type variables have no methods.
    id = Sqlite.i64("id")(cols)(stmt)?
```

Same error at `examples/sqlite-everything.roc:204` and `:219`.

## Root cause

`lookup_value!` found a column with `cols.find_first_index(...)`. The decoder combinators are deliberately unannotated, so the compiler has not worked out what `cols` is at that point, and it carries the question into whatever decoder an application writes, where it still cannot be answered. roc-lang/roc#10984 stopped those questions sharing an answer between calls, so a decoder with a name of its own asks about `cols` once per column and gets nowhere.

Only named decoders break. The inline `rows: |cols| |stmt| ...` form waits for `query_many!` to say what `cols` is, which is why the count is three and not more.

Applications cannot work around it. `query_many!` unwraps the opaque `Stmt` and hands the decoder a `Host.SqliteStmt`, and `Host` is not in the platform's `exposes` list, so there is no annotation an app is able to write.

## Fix

- call the builtin by name in `lookup_value!`: `List.find_first_index(cols, ...)`. That says which type the lookup comes from, so `cols` settles as a `List(Str)` where it is asked about and nothing is left for the application to answer. `platform/Path.roc:558` already reads the same lookup this way
- add an `expect` covering a row decoder with a name of its own, which is the shape that breaks
- move CI from `nightly-2026-08-23-fb208ba` to `nightly-2026-08-30-34e7489`. #10984 does not exist at the old pin, so neither the bug nor the test guarding it shows up there. I will drop bumping the nightly if you would rather move the pin separately.

No signature changes, so `src/roc_platform_abi.rs` and `ci/regenerate_glue.sh` are untouched: `lookup_value!` is module-private, sits outside the `Sqlite :: [].{}` block, and appears in no `requires`, `provides` or `hosted` block.

## Verification

The test was checked against the bug on `nightly-2026-08-30-34e7489`:

| `platform/Sqlite.roc` | `roc test platform/main.roc` |
| --- | --- |
| this PR | exit 0 |
| fix reverted, test kept | exit 1 |

Note that `roc test` prints `All (208) tests passed` even when the type error fires, so the exit code is the signal here, not the summary line.

`./scripts/test.py` was not run. The build and run stages, and the two `test_spec.json` cases per SQLite example, are for CI to confirm. The change is Roc-only and moves no program output.

`roc fmt --check` already fails on `platform/Cmd.roc`, `platform/InternalSqlite.roc` and `platform/Url.roc` on both nightlies, unrelated to this change and untouched by it.
