### PR TITLE
Return an open error union from Path.to_str

### DIFF
--- a/platform/Path.roc
+++ b/platform/Path.roc
@@ -226,7 +226,7 @@ Path := [
 	windows_u16s = |list| Windows(list)
 
 	## Convert a path to a string if its raw representation is valid text.
-	to_str : Path -> Try(Str, [InvalidStr(U64)])
+	to_str : Path -> Try(Str, [InvalidStr(U64), ..])
 	to_str = |path|
 		match path {
 			Utf8(str) => Ok(str)
@@ -432,7 +432,7 @@ utf8_to_utf16 = |remaining, out|
 		}
 	}
 
-utf16_to_str : List(U16) -> Try(Str, [InvalidStr(U64)])
+utf16_to_str : List(U16) -> Try(Str, [InvalidStr(U64), ..])
 utf16_to_str = |u16s|
 	match utf16_to_utf8(u16s, [], 0) {
 		Ok(bytes) =>


### PR DESCRIPTION
Every other fallible function in the platform declares an open error union so its errors can combine with the errors of other `?` calls in the same function, but `Path.to_str` declared a closed `[InvalidStr(U64)]`. A function that used both `Path.to_str(...)?` and `Stdout.line!(...)?` therefore failed to type-check (see roc-lang/roc#11030). This changes `to_str` and the `utf16_to_str` helper it delegates to so they declare `[InvalidStr(U64), ..]`.