### PR TITLE
Add native scripting APIs and managed resource cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427 # ratchet:roc-lang/setup-roc@v0.3.0
         with:
           version: nightly-new-compiler
-          nightly-tag: nightly-2026-08-30-34e7489
+          nightly-tag: nightly-2026-09-04-c125b82
       - name: Install Rust toolchain
         run: |
           rustup toolchain install "${{ needs.rust-version.outputs.version }}" --profile minimal --target x86_64-unknown-linux-musl --component llvm-tools-preview
@@ -48,6 +48,11 @@ jobs:
         run: python3 -m unittest scripts/test_check_release_version.py
       - name: Format, check, and test examples
         run: ./scripts/test.py --operation validate
+      - name: Check native resource ownership with glibc and Valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes valgrind
+          python3 scripts/test_resource_lifetimes.py
 
   validate-windows:
     name: validate sources (windows)
@@ -58,7 +63,7 @@ jobs:
       - uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427 # ratchet:roc-lang/setup-roc@v0.3.0
         with:
           version: nightly-new-compiler
-          nightly-tag: nightly-2026-08-30-34e7489
+          nightly-tag: nightly-2026-09-04-c125b82
       - name: Install Rust toolchain
         shell: bash
         run: |
@@ -103,7 +108,7 @@ jobs:
       - uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427 # ratchet:roc-lang/setup-roc@v0.3.0
         with:
           version: nightly-new-compiler
-          nightly-tag: nightly-2026-08-30-34e7489
+          nightly-tag: nightly-2026-09-04-c125b82
       - name: Install Rust toolchain
         shell: bash
         run: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,7 +40,7 @@ jobs:
         uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
         with:
           version: nightly-new-compiler
-          nightly-tag: nightly-2026-08-23-fb208ba
+          nightly-tag: nightly-2026-09-04-c125b82
 
       - name: Restore released docs
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
         with:
           version: nightly-new-compiler
-          nightly-tag: nightly-2026-08-23-fb208ba
+          nightly-tag: nightly-2026-09-04-c125b82
 
       - name: Install Zig
         uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f
@@ -215,7 +215,7 @@ jobs:
         uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
         with:
           version: nightly-new-compiler
-          nightly-tag: nightly-2026-08-23-fb208ba
+          nightly-tag: nightly-2026-09-04-c125b82
 
       - name: Install Rust
         shell: bash
@@ -260,7 +260,7 @@ jobs:
         uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
         with:
           version: nightly-new-compiler
-          nightly-tag: nightly-2026-08-23-fb208ba
+          nightly-tag: nightly-2026-09-04-c125b82
 
       - name: Create docs staging tree
         run: mkdir -p docs-site
@@ -408,7 +408,7 @@ jobs:
         uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
         with:
           version: nightly-new-compiler
-          nightly-tag: nightly-2026-08-23-fb208ba
+          nightly-tag: nightly-2026-09-04-c125b82
 
       - name: Download release metadata
         uses: actions/download-artifact@v8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,9 @@
 Thanks for helping improve `basic-cli`.
 
 CI uses a pinned Roc nightly from [`roc-lang/nightlies`](https://github.com/roc-lang/nightlies).
-For local work, use any recent `roc` on `PATH`, or download the latest archive
-for your operating system from the
-[`roc-lang/nightlies` releases](https://github.com/roc-lang/nightlies/releases/latest).
+For local work, use the `nightly-tag` pinned in [the CI workflow](.github/workflows/ci.yml),
+matching the generated ABI. Download the archive for that tag and your operating
+system from [`roc-lang/nightlies` releases](https://github.com/roc-lang/nightlies/releases).
 
 ## Code of Conduct
 
@@ -19,7 +19,7 @@ Check the compiler available locally:
 roc version
 ```
 
-To install the latest nightly locally, extract the downloaded archive and add
+To install the pinned nightly locally, extract the downloaded archive and add
 the directory containing the `roc` executable to your `PATH`.
 
 ## Nix Development Environment
@@ -123,6 +123,21 @@ output assertions used by CI:
 ```sh
 ./scripts/test.py --operation run --target x64musl --artifact-dir dist/example-binaries --valgrind
 ```
+
+The static musl allocator is invisible to Valgrind's heap accounting: a report
+of zero heap allocations alone does not prove cleanup. On x86_64 glibc Linux,
+run the additional ownership check used by CI:
+
+```sh
+ROC=/path/to/pinned/roc python3 scripts/test_resource_lifetimes.py
+```
+
+It creates an isolated diagnostic platform under `target/`, uses glibc so
+Valgrind observes allocations, and rejects memory errors and definite/indirect
+leaks. It also tracks file descriptors. The fixtures in
+`tests/resource-lifetimes/` verify port release, stream EOF, shared aliases, command reuse, and early returns; Rust tests verify
+exactly-once native finalization and child reaping. Runtime reactor descriptors
+and reachable service state can remain until process exit.
 
 For faster local iterations when the platform host is already built:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +147,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -149,12 +167,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -162,6 +196,40 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
@@ -175,10 +243,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -193,10 +267,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "http"
@@ -295,6 +387,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +474,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +551,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e3f4237d0e4741eb50bc5584db701f1299c85fa31ff0274dd6445e79dc42d12"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +572,12 @@ checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_syscall"
@@ -462,7 +596,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -470,19 +604,24 @@ dependencies = [
 
 [[package]]
 name = "roc_host"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "bytes",
  "crossterm",
- "getrandom",
+ "getrandom 0.2.16",
  "http-body-util",
  "hyper",
  "hyper-rustls",
  "hyper-util",
  "libc",
  "libsqlite3-sys",
+ "process-wrap",
+ "same-file",
+ "socket2",
  "sys-locale",
+ "tempfile",
  "tokio",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -539,6 +678,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +727,12 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -623,17 +777,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "tokio"
 version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -659,7 +840,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -717,6 +910,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,16 +944,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -785,6 +1091,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -834,6 +1149,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roc_host"
-version = "0.22.2"
+version = "0.23.0"
 authors = ["The Roc Contributors"]
 edition = "2021"
 rust-version = "1.97"
@@ -18,6 +18,10 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(no_roc_std_helpers)"] }
 crossterm = "=0.29.0"
 getrandom = "=0.2.16"
 libc = "=0.2.180"
+tempfile = "=3.23.0"
+same-file = "=1.0.6"
+process-wrap = { version = "=10.0.0", features = ["tokio1"] }
+socket2 = "=0.5.10"
 libsqlite3-sys = { version = "=0.33.0", features = ["bundled"] }
 
 # HTTP stack (ported from the old roc_http crate). `ring` is the rustls crypto
@@ -26,11 +30,14 @@ hyper = { version = "=1.6.0", default-features = false, features = ["http1", "cl
 hyper-util = { version = "=0.1.12", default-features = false, features = ["client", "client-legacy", "http1", "tokio"] }
 hyper-rustls = { version = "=0.27.6", default-features = false, features = ["http1", "tls12", "webpki-tokio", "ring"] }
 http-body-util = "=0.1.3"
-tokio = { version = "=1.45.0", default-features = false, features = ["rt", "net", "time"] }
+tokio = { version = "=1.45.0", default-features = false, features = ["rt", "net", "time", "process", "sync", "io-util", "macros"] }
 bytes = "=1.12.1"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 sys-locale = "=0.3.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "=0.59.0", features = ["Win32_Networking_WinSock"] }
 
 [profile.release]
 lto = true

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -239,3 +239,329 @@ prospectively choose to deem waived or otherwise exclude such Section(s) of
 the License, but only in their entirety and only with respect to the Combined
 Software.
 ```
+
+## Scripting host dependencies
+
+The distributed static host archive (`libhost.a`) includes code from these new
+runtime dependencies on the supported platforms. Cargo manages their source
+downloads; the notices below accompany the compiled code in our distribution.
+For dual-licensed dependencies, the MIT license option is reproduced here.
+Versions and source checksums are recorded in `Cargo.lock`.
+
+### equivalent 1.0.2
+
+```text
+Copyright (c) 2016--2023
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
+### fastrand 2.5.0, process-wrap 10.0.0
+
+```text
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
+### futures 0.3.31, futures-executor 0.3.31, futures-io 0.3.34, futures-sink 0.3.34
+
+```text
+Copyright (c) 2016 Alex Crichton
+Copyright (c) 2017 The Tokio Authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
+### getrandom 0.3.4
+
+```text
+Copyright (c) 2018-2025 The rust-random Project Developers
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
+### hashbrown 0.17.1
+
+```text
+Copyright (c) 2016 Amanieu d'Antras
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
+### indexmap 2.14.2
+
+```text
+Copyright (c) 2016--2017
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
+### nix 0.31.1
+
+```text
+The MIT License (MIT)
+
+Copyright (c) 2015 Carl Lerche + nix-rust Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```
+
+### same-file 1.0.6, winapi-util 0.1.11
+
+```text
+The MIT License (MIT)
+
+Copyright (c) 2017 Andrew Gallant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```
+
+### slab 0.4.12
+
+```text
+Copyright (c) 2019 Carl Lerche
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
+### tempfile 3.23.0
+
+```text
+Copyright (c) 2015 Steven Allen
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
+### windows 0.62.2, windows-collections 0.3.2, windows-core 0.62.2, windows-future 0.3.2, windows-numerics 0.3.1, windows-result 0.4.1, windows-strings 0.5.1, windows-threading 0.2.1
+
+```text
+MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE
+```

--- a/examples/filesystem-tools.roc
+++ b/examples/filesystem-tools.roc
@@ -1,0 +1,33 @@
+## Prepare a distributable directory without changing its source files.
+## Usage: roc filesystem-tools.roc -- path/to/site path/to/new-release
+app [main!] { pf: platform "../platform/main.roc" }
+
+import pf.Env
+import pf.OsStr
+import pf.Path
+import pf.Stdout
+
+main! : List(OsStr) => Try({}, _)
+main! = |args| {
+	(source_arg, destination_arg) = match args.drop_first(1) {
+		[source, destination] => (source, destination)
+		_ => return Err(MissingPaths)
+	}
+	source = Path.from_os_str(source_arg)
+	destination = Path.from_os_str(destination_arg)
+
+	# Prepare everything in a private workspace. It is removed on success or error.
+	Env.with_temp_dir!(
+		|workspace| {
+			staged = Path.join(workspace, "release")
+			Path.copy_dir!(source, staged)?
+			Path.write_utf8!(Path.join(staged, "RELEASE.txt"), "Prepared with basic-cli\n")?
+
+			# The destination must be new, protecting an existing release from overwrite.
+			Path.copy_dir!(staged, destination)?
+			Ok({})
+		},
+	)?
+	resolved = Path.canonicalize!(destination)?
+	Stdout.line!("Release prepared at ${Path.display(resolved)}")
+}

--- a/examples/process-control.roc
+++ b/examples/process-control.roc
@@ -1,0 +1,40 @@
+## Run a build command with live output and a five-minute deadline.
+## Usage: roc process-control.roc -- cargo build --release
+app [main!] { pf: platform "../platform/main.roc" }
+
+import pf.Cmd
+import pf.OsStr
+import pf.Stderr
+import pf.Stdout
+
+main! : List(OsStr) => Try({}, _)
+main! = |args| {
+	(program, arguments) = match args.drop_first(1) {
+		[command, .. as rest] => (command, rest)
+		[] => return Err(MissingCommand)
+	}
+
+	# Pass native arguments directly: spaces and shell characters stay literal.
+	child = Cmd.new(program)
+		.args(arguments)
+		.stdin(Null)
+		.stdout(Tee)
+		.stderr(Tee)
+		.timeout_ms(300_000)
+		.manage_tree(Bool.True)
+		.spawn!() ? |err| StartFailed(err)
+
+	pid = child.pid!() ? |err| ProcessFailed(err)
+	Stdout.line!("Running ${OsStr.display(program)} (pid ${pid.to_str()})")?
+
+	# Both streams are drained concurrently. Tee also keeps a bounded capture.
+	# The deadline terminates the managed process tree if the build gets stuck.
+	output = child.wait!() ? |err| BuildInterrupted(err)
+	match output.status {
+		Exited(0) => Stdout.line!("Build completed successfully")
+		status => {
+			Stderr.line!("Build failed: ${Str.inspect(status)}")?
+			Err(BuildFailed(status))
+		}
+	}
+}

--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787662017,
-        "narHash": "sha256-rf1gFF/zgSKvyu9fVZoSgW9KCpt4FmzpKW3rlObHPwA=",
+        "lastModified": 1788608813,
+        "narHash": "sha256-ycPYsax6QTQIisQGZHZ+i6mJm6pav35mccWA7MuwGnc=",
         "owner": "roc-lang",
         "repo": "roc-overlay",
-        "rev": "8a0e83fb3d4d6569577482d21788612580ea21f1",
+        "rev": "686a4300d9a5e302582aa105de1335010ad1340d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
           default = pkgs.mkShell {
             packages = [
               # Keep in sync with the nightly pinned in .github/workflows.
-              pkgs.rocpkgs."nightly-2026-08-23-fb208ba"
+              pkgs.rocpkgs."nightly-2026-09-04-c125b82"
               pkgs.python3
               rustToolchain
               pkgs.simple-http-server

--- a/platform/Cmd.roc
+++ b/platform/Cmd.roc
@@ -11,6 +11,15 @@ Cmd :: {
 	clear_envs : Bool,
 	envs : List((OsStr, OsStr)),
 	program : OsStr,
+	cwd_value : List(Path),
+	stdin_value : [Default, Inherit, Null, Bytes(List(U8)), Pipe],
+	stdout_value : [Default, Inherit, Null, Capture, Pipe, Tee],
+	stderr_value : [Default, Inherit, Null, Capture, Pipe, Tee],
+	timeout_value : U64,
+	output_limit_value : U64,
+	pending_limit_value : U64,
+	manage_tree_value : Bool,
+	merge_stderr_value : Bool,
 }.{
 
 	## Simplest way to execute a command by name with arguments.
@@ -161,11 +170,67 @@ Cmd :: {
 		clear_envs: Bool.False,
 		envs: [],
 		program,
+		cwd_value: [],
+		stdin_value: Default,
+		stdout_value: Default,
+		stderr_value: Default,
+		timeout_value: 0,
+		output_limit_value: 16777216,
+		pending_limit_value: 1048576,
+		manage_tree_value: Bool.False,
+		merge_stderr_value: Bool.False,
 	}
 
 	## Create a new command from a Roc string.
 	new_str : Str -> Cmd
 	new_str = |program| new(OsStr.from_str(program))
+
+	## Set the child working directory without changing the parent directory.
+	## Use an absolute executable path or a bare PATH name: resolving a relative
+	## executable against cwd is platform-specific.
+	cwd : Cmd, Path -> Cmd
+	cwd = |cmd, path| { ..cmd, cwd_value: [path] }
+	## Bytes supplies and closes stdin automatically. Pipe supports Child.write!.
+	## Default is Null for run!/exec_output!, Inherit for spawn!/exec_cmd!.
+	stdin : Cmd, [Default, Inherit, Null, Bytes(List(U8)), Pipe] -> Cmd
+	stdin = |cmd, mode| { ..cmd, stdin_value: mode }
+	## Capture retains bytes; Pipe queues tagged Child.read! events; Tee captures
+	## and forwards to the parent. Default captures for run!/exec_output!, and
+	## inherits for spawn!/exec_cmd!. Tee exposes a pipe, not a terminal, to the child.
+	stdout : Cmd, [Default, Inherit, Null, Capture, Pipe, Tee] -> Cmd
+	stdout = |cmd, mode| { ..cmd, stdout_value: mode }
+	## Configure stderr independently, with the same modes and defaults as stdout.
+	stderr : Cmd, [Default, Inherit, Null, Capture, Pipe, Tee] -> Cmd
+	stderr = |cmd, mode| { ..cmd, stderr_value: mode }
+
+	## Zero disables the execution deadline. It covers output draining too.
+	timeout_ms : Cmd, U64 -> Cmd
+	timeout_ms = |cmd, millis| { ..cmd, timeout_value: millis }
+	## Combined capture budget in bytes (default 16 MiB). Exceeding it cancels
+	## the command and returns OutputLimit with the retained partial output.
+	output_limit : Cmd, U64 -> Cmd
+	output_limit = |cmd, bytes| { ..cmd, output_limit_value: bytes }
+	## Combined unread Pipe event budget (default 1 MiB). Consume events with
+	## Child.read! while running; exceeding this budget cancels the child.
+	pending_limit : Cmd, U64 -> Cmd
+	pending_limit = |cmd, bytes| { ..cmd, pending_limit_value: bytes }
+	## Also terminate descendants on cancellation, using a Unix process group
+	## or Windows Job Object. Disabled by default; descendants must not escape it.
+	manage_tree : Cmd, Bool -> Cmd
+	manage_tree = |cmd, enabled| { ..cmd, manage_tree_value: enabled }
+	## Send both child streams into one OS pipe using stdout's mode and budget.
+	## This preserves kernel write order; separate streams have no total ordering.
+	merge_stderr : Cmd, Bool -> Cmd
+	merge_stderr = |cmd, enabled| { ..cmd, merge_stderr_value: enabled }
+
+	## Nonzero exits and signal termination are returned as status data.
+	## Defaults to null stdin and captured stdout/stderr. Successful completion
+	## waits for output EOF; deadlines include draining and tee forwarding.
+	run! : Cmd => Try(RunOutput, RunErr)
+	run! = |cmd| decode_run(Host.cmd_run!(to_host_cmd(cmd)).map_err(|err| IO(err))?)
+	## Start a managed child immediately. Default streams are inherited.
+	spawn! : Cmd => Try(Child, IOErr)
+	spawn! = |cmd| Host.cmd_spawn!(to_host_cmd(cmd)).map_ok(|handle| Child.{ host: handle })
 
 	## Add a single argument to the command.
 	## ❗ Shell features like variable substitution (e.g. `$FOO`), glob patterns (e.g. `*.txt`), ... are not available.
@@ -253,7 +318,7 @@ Cmd :: {
 	## exception.
 	check_available! : Str => Bool
 	check_available! = |command| {
-		is_windows = 
+		is_windows =
 			match Env.platform!().os {
 				WINDOWS => Bool.True
 				_ => Bool.False
@@ -262,7 +327,7 @@ Cmd :: {
 		if has_separator(command, is_windows) {
 			candidate_available!(Path.utf8(command), is_windows)
 		} else {
-			path_value = 
+			path_value =
 				match Env.var!(OsStr.from_str("PATH")) {
 					Ok(value) => value
 					Err(_) => OsStr.from_str("")
@@ -280,7 +345,54 @@ Cmd :: {
 	## Render a command configuration as a stable, escaped string.
 	to_str : Cmd -> Str
 	to_str = |cmd|
-		"Cmd({ program: ${Str.inspect(cmd.program)}, args: ${Str.inspect(cmd.args)}, envs: ${Str.inspect(cmd.envs)}, clear_envs: ${Str.inspect(cmd.clear_envs)} })"
+		"Cmd({ program: ${Str.inspect(cmd.program)}, args: ${Str.inspect(cmd.args)}, envs: ${Str.inspect(cmd.envs)}, clear_envs: ${Str.inspect(cmd.clear_envs)}, cwd: ${Str.inspect(cmd.cwd_value)}, stdin: ${Str.inspect(cmd.stdin_value)}, stdout: ${Str.inspect(cmd.stdout_value)}, stderr: ${Str.inspect(cmd.stderr_value)}, timeout_ms: ${Str.inspect(cmd.timeout_value)}, output_limit: ${Str.inspect(cmd.output_limit_value)}, pending_limit: ${Str.inspect(cmd.pending_limit_value)}, manage_tree: ${Str.inspect(cmd.manage_tree_value)}, merge_stderr: ${Str.inspect(cmd.merge_stderr_value)} })"
+
+	RunOutput : { status : [Exited(I32), Signaled(I32)], stdout_bytes : List(U8), stderr_bytes : List(U8) }
+	PartialOutput : { stdout_bytes : List(U8), stderr_bytes : List(U8) }
+	RunErr : [IO(IOErr), Timeout(PartialOutput), OutputLimit(PartialOutput)]
+
+	## A managed child. Final reference release terminates and reaps the process.
+	## Use close! for deterministic cleanup before the last reference is released.
+	Child :: { host : Host.Child }.{
+		pid! : Child => Try(U32, IOErr)
+		pid! = |child| Host.child_pid!(child.host)
+
+		## Closes piped stdin before waiting; call read!/write! for an interactive exchange first.
+		wait! : Child => Try(RunOutput, RunErr)
+		wait! = |child| decode_run(Host.child_wait!(child.host).map_err(|err| IO(err))?)
+		## Returns [] while running, or one result after exit and output draining.
+		try_wait! : Child => Try(List(RunOutput), RunErr)
+		try_wait! = |child| {
+			values = Host.child_try_wait!(child.host).map_err(|err| IO(err))?
+			match values {
+				[] => Ok([])
+				[value, ..] => Ok([decode_run(value)?])
+			}
+		}
+		## Request forced termination. Use wait! to observe termination and reaping.
+		kill! : Child => Try({}, IOErr)
+		kill! = |child| Host.child_kill!(child.host)
+		## Terminate and reap, invalidating every alias. Repeated close! succeeds.
+		close! : Child => Try({}, IOErr)
+		close! = |child| Host.child_close!(child.host)
+		close_stdin! : Child => Try({}, IOErr)
+		close_stdin! = |child| Host.child_close_stdin!(child.host)
+		## Write piped stdin within timeout milliseconds. A timed-out write may
+		## have delivered a prefix; retrying the whole input can duplicate bytes.
+		write! : Child, List(U8), U64 => Try({}, IOErr)
+		write! = |child, bytes, timeout| Host.child_write!(child.host, bytes, timeout)
+
+		## Returns one stream chunk, or End after all output drains. Timeout is an IO error.
+		read! : Child, U64, U64 => Try([Stdout(List(U8)), Stderr(List(U8)), End], IOErr)
+		read! = |child, max_bytes, timeout| {
+			event = Host.child_read!(child.host, max_bytes, timeout)?
+			Ok(match event.stream {
+				1 => Stdout(event.bytes)
+				2 => Stderr(event.bytes)
+				_ => End
+			})
+		}
+	}
 
 	## Customize command output for `Str.inspect`.
 	to_inspect : Cmd -> Str
@@ -307,6 +419,25 @@ to_host_cmd = |cmd| {
 	clear_envs: cmd.clear_envs,
 	envs: flatten_arg_pairs(cmd.envs, [], 0).map(OsStr.to_raw),
 	program: OsStr.to_raw(cmd.program),
+	cwd: cmd.cwd_value.map(Path.to_raw),
+	stdin_mode: match cmd.stdin_value {
+		Default => 0
+		Inherit => 1
+		Null => 2
+		Bytes(_) => 3
+		Pipe => 4
+	},
+	stdout_mode: output_mode(cmd.stdout_value),
+	stderr_mode: output_mode(cmd.stderr_value),
+	stdin_bytes: match cmd.stdin_value {
+		Bytes(bytes) => bytes
+		_ => []
+	},
+	timeout_ms: cmd.timeout_value,
+	output_limit: cmd.output_limit_value,
+	pending_limit: cmd.pending_limit_value,
+	manage_tree: cmd.manage_tree_value,
+	merge_stderr: cmd.merge_stderr_value,
 }
 
 ## A command name is a path, rather than a bare name, when it carries a separator.
@@ -411,7 +542,7 @@ expect {
 		.env_str("NAME", "Roc")
 		.clear_envs()
 
-	Str.inspect(cmd) == "Cmd({ program: OsStr.utf8(\"echo\\nnext\"), args: [OsStr.utf8(\"hello world\")], envs: [(OsStr.utf8(\"NAME\"), OsStr.utf8(\"Roc\"))], clear_envs: True })"
+	Str.inspect(cmd) == "Cmd({ program: OsStr.utf8(\"echo\\nnext\"), args: [OsStr.utf8(\"hello world\")], envs: [(OsStr.utf8(\"NAME\"), OsStr.utf8(\"Roc\"))], clear_envs: True, cwd: [], stdin: Default, stdout: Default, stderr: Default, timeout_ms: 0, output_limit: 16777216, pending_limit: 1048576, manage_tree: False, merge_stderr: False })"
 }
 
 ## A name is a path only when it carries a separator for the current platform.
@@ -441,4 +572,24 @@ expect path_dirs(OsStr.utf8("/a::/b:"), Bool.False) == [Path.utf8("/a"), Path.ut
 expect {
 	path = OsStr.windows_u16s([0x43, 0x3B, 0x44])
 	path_dirs(path, Bool.True) == [Path.windows_u16s([0x43]), Path.windows_u16s([0x44])]
+}
+
+output_mode : [Default, Inherit, Null, Capture, Pipe, Tee] -> U8
+output_mode = |mode| match mode {
+	Default => 0
+	Inherit => 1
+	Null => 2
+	Capture => 3
+	Pipe => 4
+	Tee => 5
+}
+
+decode_run : Host.CmdRunResult -> Try(Cmd.RunOutput, Cmd.RunErr)
+decode_run = |value| {
+	partial = { stdout_bytes: value.stdout_bytes, stderr_bytes: value.stderr_bytes }
+	match value.failure {
+		1 => Err(Timeout(partial))
+		2 => Err(OutputLimit(partial))
+		_ => Ok({ stdout_bytes: partial.stdout_bytes, stderr_bytes: partial.stderr_bytes, status: if value.signal == 0 Exited(value.exit_code) else Signaled(value.signal) })
+	}
 }

--- a/platform/Cmd.roc
+++ b/platform/Cmd.roc
@@ -6,6 +6,21 @@ import Path exposing [Path]
 
 ## Build and run child processes with native-safe programs, arguments, and
 ## environment values.
+##
+## Use `run!` when exit status and output are data your application handles:
+##
+## ```roc
+## output = Cmd.new_str("roc")
+## 	.arg_str("version")
+## 	.timeout_ms(5_000)
+## 	.run!()?
+##
+## match output.status {
+## 	Exited(0) => Stdout.write_bytes!(output.stdout_bytes)
+## 	Exited(code) => Err(CommandFailed(code))
+## 	Signaled(signal) => Err(CommandSignaled(signal))
+## }
+## ```
 Cmd :: {
 	args : List(OsStr),
 	clear_envs : Bool,
@@ -53,7 +68,7 @@ Cmd :: {
 	##
 	## ```roc
 	## Cmd.new("cargo")
-	##     .arg(["build")
+	##     .arg("build")
 	##     .env("RUST_BACKTRACE", "1")
 	##     .exec_cmd!()?
 	## ```
@@ -119,7 +134,7 @@ Cmd :: {
 	##         .args(["Hi"])
 	##         .exec_output_bytes!()?
 	##
-	## Stdout.line!("${Str.inspect(cmd_output_bytes)}")? # {stderr_bytes: [], stdout_bytes: [72, 105, 10]}
+	## Stdout.line!("${Str.inspect(cmd_output)}")? # {stderr_bytes: [], stdout_bytes: [72, 105, 10]}
 	## ```
 	exec_output_bytes! : Cmd => Try({ stderr_bytes : List(U8), stdout_bytes : List(U8) }, [NonZeroExitCodeB({ exit_code : I32, stdout_bytes : List(U8), stderr_bytes : List(U8) }), FailedToGetExitCodeB(IOErr), ..])
 	exec_output_bytes! = |cmd| {
@@ -190,15 +205,18 @@ Cmd :: {
 	## executable against cwd is platform-specific.
 	cwd : Cmd, Path -> Cmd
 	cwd = |cmd, path| { ..cmd, cwd_value: [path] }
+
 	## Bytes supplies and closes stdin automatically. Pipe supports Child.write!.
 	## Default is Null for run!/exec_output!, Inherit for spawn!/exec_cmd!.
 	stdin : Cmd, [Default, Inherit, Null, Bytes(List(U8)), Pipe] -> Cmd
 	stdin = |cmd, mode| { ..cmd, stdin_value: mode }
+
 	## Capture retains bytes; Pipe queues tagged Child.read! events; Tee captures
 	## and forwards to the parent. Default captures for run!/exec_output!, and
 	## inherits for spawn!/exec_cmd!. Tee exposes a pipe, not a terminal, to the child.
 	stdout : Cmd, [Default, Inherit, Null, Capture, Pipe, Tee] -> Cmd
 	stdout = |cmd, mode| { ..cmd, stdout_value: mode }
+
 	## Configure stderr independently, with the same modes and defaults as stdout.
 	stderr : Cmd, [Default, Inherit, Null, Capture, Pipe, Tee] -> Cmd
 	stderr = |cmd, mode| { ..cmd, stderr_value: mode }
@@ -206,18 +224,22 @@ Cmd :: {
 	## Zero disables the execution deadline. It covers output draining too.
 	timeout_ms : Cmd, U64 -> Cmd
 	timeout_ms = |cmd, millis| { ..cmd, timeout_value: millis }
+
 	## Combined capture budget in bytes (default 16 MiB). Exceeding it cancels
 	## the command and returns OutputLimit with the retained partial output.
 	output_limit : Cmd, U64 -> Cmd
 	output_limit = |cmd, bytes| { ..cmd, output_limit_value: bytes }
+
 	## Combined unread Pipe event budget (default 1 MiB). Consume events with
 	## Child.read! while running; exceeding this budget cancels the child.
 	pending_limit : Cmd, U64 -> Cmd
 	pending_limit = |cmd, bytes| { ..cmd, pending_limit_value: bytes }
+
 	## Also terminate descendants on cancellation, using a Unix process group
 	## or Windows Job Object. Disabled by default; descendants must not escape it.
 	manage_tree : Cmd, Bool -> Cmd
 	manage_tree = |cmd, enabled| { ..cmd, manage_tree_value: enabled }
+
 	## Send both child streams into one OS pipe using stdout's mode and budget.
 	## This preserves kernel write order; separate streams have no total ordering.
 	merge_stderr : Cmd, Bool -> Cmd
@@ -228,6 +250,7 @@ Cmd :: {
 	## waits for output EOF; deadlines include draining and tee forwarding.
 	run! : Cmd => Try(RunOutput, RunErr)
 	run! = |cmd| decode_run(Host.cmd_run!(to_host_cmd(cmd)).map_err(|err| IO(err))?)
+
 	## Start a managed child immediately. Default streams are inherited.
 	spawn! : Cmd => Try(Child, IOErr)
 	spawn! = |cmd| Host.cmd_spawn!(to_host_cmd(cmd)).map_ok(|handle| Child.{ host: handle })
@@ -347,19 +370,29 @@ Cmd :: {
 	to_str = |cmd|
 		"Cmd({ program: ${Str.inspect(cmd.program)}, args: ${Str.inspect(cmd.args)}, envs: ${Str.inspect(cmd.envs)}, clear_envs: ${Str.inspect(cmd.clear_envs)}, cwd: ${Str.inspect(cmd.cwd_value)}, stdin: ${Str.inspect(cmd.stdin_value)}, stdout: ${Str.inspect(cmd.stdout_value)}, stderr: ${Str.inspect(cmd.stderr_value)}, timeout_ms: ${Str.inspect(cmd.timeout_value)}, output_limit: ${Str.inspect(cmd.output_limit_value)}, pending_limit: ${Str.inspect(cmd.pending_limit_value)}, manage_tree: ${Str.inspect(cmd.manage_tree_value)}, merge_stderr: ${Str.inspect(cmd.merge_stderr_value)} })"
 
+	## The completed child status and captured output. Output is empty for streams
+	## configured as `Inherit` or `Null`.
 	RunOutput : { status : [Exited(I32), Signaled(I32)], stdout_bytes : List(U8), stderr_bytes : List(U8) }
+
+	## Output retained before a timeout or capture limit stopped the command.
 	PartialOutput : { stdout_bytes : List(U8), stderr_bytes : List(U8) }
+
+	## A failure to start or supervise a command, an expired deadline, or a full
+	## capture budget. Nonzero exit codes are represented by `RunOutput.status`.
 	RunErr : [IO(IOErr), Timeout(PartialOutput), OutputLimit(PartialOutput)]
 
 	## A managed child. Final reference release terminates and reaps the process.
 	## Use close! for deterministic cleanup before the last reference is released.
 	Child :: { host : Host.Child }.{
+
+		## Return the operating-system process identifier while the child is open.
 		pid! : Child => Try(U32, IOErr)
 		pid! = |child| Host.child_pid!(child.host)
 
 		## Closes piped stdin before waiting; call read!/write! for an interactive exchange first.
 		wait! : Child => Try(RunOutput, RunErr)
 		wait! = |child| decode_run(Host.child_wait!(child.host).map_err(|err| IO(err))?)
+
 		## Returns [] while running, or one result after exit and output draining.
 		try_wait! : Child => Try(List(RunOutput), RunErr)
 		try_wait! = |child| {
@@ -369,14 +402,19 @@ Cmd :: {
 				[value, ..] => Ok([decode_run(value)?])
 			}
 		}
+
 		## Request forced termination. Use wait! to observe termination and reaping.
 		kill! : Child => Try({}, IOErr)
 		kill! = |child| Host.child_kill!(child.host)
+
 		## Terminate and reap, invalidating every alias. Repeated close! succeeds.
 		close! : Child => Try({}, IOErr)
 		close! = |child| Host.child_close!(child.host)
+
+		## Close piped stdin so the child observes EOF. Repeated closes succeed.
 		close_stdin! : Child => Try({}, IOErr)
 		close_stdin! = |child| Host.child_close_stdin!(child.host)
+
 		## Write piped stdin within timeout milliseconds. A timed-out write may
 		## have delivered a prefix; retrying the whole input can duplicate bytes.
 		write! : Child, List(U8), U64 => Try({}, IOErr)
@@ -386,11 +424,13 @@ Cmd :: {
 		read! : Child, U64, U64 => Try([Stdout(List(U8)), Stderr(List(U8)), End], IOErr)
 		read! = |child, max_bytes, timeout| {
 			event = Host.child_read!(child.host, max_bytes, timeout)?
-			Ok(match event.stream {
-				1 => Stdout(event.bytes)
-				2 => Stderr(event.bytes)
-				_ => End
-			})
+			Ok(
+				match event.stream {
+					1 => Stdout(event.bytes)
+					2 => Stderr(event.bytes)
+					_ => End
+				},
+			)
 		}
 	}
 

--- a/platform/Cmd.roc
+++ b/platform/Cmd.roc
@@ -10,8 +10,8 @@ import Path exposing [Path]
 ## Use `run!` when exit status and output are data your application handles:
 ##
 ## ```roc
-## output = Cmd.new_str("roc")
-## 	.arg_str("version")
+## output = Cmd.new("roc")
+## 	.arg("version")
 ## 	.timeout_ms(5_000)
 ## 	.run!()?
 ##
@@ -196,7 +196,8 @@ Cmd :: {
 		merge_stderr_value: Bool.False,
 	}
 
-	## Create a new command from a Roc string.
+	## Create a new command from a dynamic `Str`. String literals can be passed
+	## directly to [new].
 	new_str : Str -> Cmd
 	new_str = |program| new(OsStr.from_str(program))
 
@@ -267,7 +268,7 @@ Cmd :: {
 		args: cmd.args.append(a),
 	}
 
-	## Add a single string argument to the command.
+	## Add a dynamic `Str` argument. String literals can be passed directly to [arg].
 	arg_str : Cmd, Str -> Cmd
 	arg_str = |cmd, a| arg(cmd, OsStr.from_str(a))
 
@@ -283,7 +284,8 @@ Cmd :: {
 		args: cmd.args.concat(new_args),
 	}
 
-	## Add multiple string arguments to the command.
+	## Add multiple dynamic `Str` arguments. Lists of string literals can be passed
+	## directly to [args].
 	args_str : Cmd, List(Str) -> Cmd
 	args_str = |cmd, new_args| args(cmd, new_args.map(OsStr.from_str))
 
@@ -298,7 +300,8 @@ Cmd :: {
 		{ ..cmd, envs: cmd.envs.append((key, value)) }
 	}
 
-	## Add a single string environment variable to the command.
+	## Add a dynamic `Str` environment variable. String literals can be passed
+	## directly to [env].
 	env_str : Cmd, Str, Str -> Cmd
 	env_str = |cmd, key, value| env(cmd, OsStr.from_str(key), OsStr.from_str(value))
 
@@ -310,7 +313,8 @@ Cmd :: {
 	envs : Cmd, List((OsStr, OsStr)) -> Cmd
 	envs = |cmd, pairs| { ..cmd, envs: cmd.envs.concat(pairs) }
 
-	## Add multiple string environment variables to the command.
+	## Add multiple dynamic `Str` environment variables. Lists of literal pairs can
+	## be passed directly to [envs].
 	envs_str : Cmd, List((Str, Str)) -> Cmd
 	envs_str = |cmd, pairs| {
 		arg_pairs = pairs.map(|(key, value)| (OsStr.from_str(key), OsStr.from_str(value)))

--- a/platform/Env.roc
+++ b/platform/Env.roc
@@ -8,6 +8,11 @@ import Path
 ## Variable names and values use [`OsStr`](OsStr) because Unix environment data
 ## is not required to be UTF-8. Use [`var_str!`](#var_str!) when an application
 ## specifically requires text. Paths use basic-cli's byte-preserving `Path` type.
+##
+## ```roc
+## path_value = Env.var_str!("PATH")?
+## Stdout.line!("PATH: ${path_value}")?
+## ```
 Env :: [].{
 
 	## Report the architecture and operating system for which the host was built.
@@ -96,6 +101,14 @@ Env :: [].{
 
 	## Run a callback with a private directory and delete the directory afterward.
 	## Cleanup is attempted after callback success and failure. If both fail, both errors are returned.
+	##
+	## ```roc
+	## Env.with_temp_dir!(|directory| {
+	## 	file = Path.join(directory, "result.txt")
+	## 	Path.write_utf8!(file, "temporary data")?
+	## 	Path.read_utf8!(file)
+	## })?
+	## ```
 	with_temp_dir! : (Path.Path => Try(a, err)) => Try(a, [TempDirErr(IOErr), CallbackErr(err), CleanupErr(IOErr, Path.Path), CallbackAndCleanupErr(err, IOErr, Path.Path), ..])
 	with_temp_dir! = |callback!| {
 		path = create_temp_dir!()?

--- a/platform/Env.roc
+++ b/platform/Env.roc
@@ -79,6 +79,36 @@ Env :: [].{
 			Err(ExePathUnavailable) => Err(ExePathUnavailable)
 		}
 
+	## Atomically create a private directory in the system temporary directory.
+	## The caller owns cleanup. Unix directories have mode 0700.
+	create_temp_dir! : () => Try(Path.Path, [TempDirErr(IOErr), ..])
+	create_temp_dir! = || create_temp_dir_with_prefix!("roc-")
+
+	## Create a private temporary directory with a filename prefix.
+	create_temp_dir_with_prefix! : Str => Try(Path.Path, [TempDirErr(IOErr), ..])
+	create_temp_dir_with_prefix! = |prefix| create_temp_dir_in!(temp_dir!(), prefix)
+
+	## Create a private temporary directory under an existing parent directory.
+	## Prefixes cannot contain separators, colons, NUL, or be `.` or `..`.
+	create_temp_dir_in! : Path.Path, Str => Try(Path.Path, [TempDirErr(IOErr), ..])
+	create_temp_dir_in! = |parent, prefix|
+		Host.env_create_temp_dir!(Path.to_raw(parent), prefix).map_ok(Path.from_raw).map_err(|err| TempDirErr(err))
+
+	## Run a callback with a private directory and delete the directory afterward.
+	## Cleanup is attempted after callback success and failure. If both fail, both errors are returned.
+	with_temp_dir! : (Path.Path => Try(a, err)) => Try(a, [TempDirErr(IOErr), CallbackErr(err), CleanupErr(IOErr, Path.Path), CallbackAndCleanupErr(err, IOErr, Path.Path), ..])
+	with_temp_dir! = |callback!| {
+		path = create_temp_dir!()?
+		result = callback!(path)
+		cleanup = Path.delete_all!(path)
+		match (result, cleanup) {
+			(Ok(value), Ok(_)) => Ok(value)
+			(Err(err), Ok(_)) => Err(CallbackErr(err))
+			(Ok(_), Err(PathErr(err, failed_path))) => Err(CleanupErr(err, failed_path))
+			(Err(callback_err), Err(PathErr(err, failed_path))) => Err(CallbackAndCleanupErr(callback_err, err, failed_path))
+		}
+	}
+
 	## Gets the default directory for temporary files.
 	temp_dir! : () => Path.Path
 	temp_dir! = || Path.from_raw(Host.env_temp_dir!())

--- a/platform/Host.roc
+++ b/platform/Host.roc
@@ -10,6 +10,16 @@ Host :: [].{
 	Cmd : {
 		args : List(NativeOsStr),
 		clear_envs : Bool,
+		cwd : List(NativeOsStr),
+		stdin_mode : U8,
+		stdout_mode : U8,
+		stderr_mode : U8,
+		stdin_bytes : List(U8),
+		timeout_ms : U64,
+		output_limit : U64,
+		pending_limit : U64,
+		manage_tree : Bool,
+		merge_stderr : Bool,
 		envs : List(NativeOsStr),
 		program : NativeOsStr,
 	}
@@ -118,4 +128,33 @@ Host :: [].{
 	}
 	env_dict! : () => List((NativeOsStr, NativeOsStr))
 	env_set_cwd! : NativePath => Try({}, IOErr)
+
+	CopyOptions : { symlinks : [Follow, Preserve], destination : [RequireNew, Merge] }
+	CopyFailure : { operation : Str, source : NativePath, destination : NativePath, error : IOErr }
+	path_copy! : NativePath, NativePath => Try({}, CopyFailure)
+	path_copy_dir! : NativePath, NativePath, CopyOptions => Try({}, CopyFailure)
+	path_absolute! : NativePath => Try(NativePath, IOErr)
+	path_canonicalize! : NativePath => Try(NativePath, IOErr)
+	env_create_temp_dir! : NativePath, Str => Try(NativePath, IOErr)
+	monotonic_now! : () => U64
+
+	Child :: Box(U64)
+	CmdRunResult : { exit_code : I32, signal : I32, stdout_bytes : List(U8), stderr_bytes : List(U8), failure : U8 }
+	ChildEvent : { stream : U8, bytes : List(U8) }
+	cmd_spawn! : Cmd => Try(Child, IOErr)
+	cmd_run! : Cmd => Try(CmdRunResult, IOErr)
+	child_pid! : Child => Try(U32, IOErr)
+	child_wait! : Child => Try(CmdRunResult, IOErr)
+	child_try_wait! : Child => Try(List(CmdRunResult), IOErr)
+	child_kill! : Child => Try({}, IOErr)
+	child_close! : Child => Try({}, IOErr)
+	child_close_stdin! : Child => Try({}, IOErr)
+	child_write! : Child, List(U8), U64 => Try({}, IOErr)
+	child_read! : Child, U64, U64 => Try(ChildEvent, IOErr)
+
+	TcpListener :: Box(U64)
+	tcp_listen! : Str, U16, U64 => Try(TcpListener, Str)
+	tcp_local_port! : TcpListener => Try(U16, Str)
+	tcp_accept! : TcpListener, U64 => Try(TcpStream, Str)
+	tcp_listener_close! : TcpListener => Try({}, Str)
 }

--- a/platform/Monotonic.roc
+++ b/platform/Monotonic.roc
@@ -1,0 +1,11 @@
+import Host
+
+## Measure elapsed time using a clock that is unaffected by wall-clock changes.
+## Values are nanoseconds since an unspecified, process-local origin. They are
+## suitable for subtraction and must not be persisted or compared across runs.
+Monotonic :: [].{
+
+	## Read the process-local monotonic clock in nanoseconds.
+	now! : () => U64
+	now! = || Host.monotonic_now!()
+}

--- a/platform/OsStr.roc
+++ b/platform/OsStr.roc
@@ -8,12 +8,13 @@ OsStr := [
 	WindowsU16s(List(U16)),
 ].{
 
-	## Create an OS string from UTF-8 text.
-	## The host lowers this text to the active OS representation.
+	## Create an OS string from a dynamic UTF-8 `Str`. String literals can be used
+	## directly wherever an `OsStr` is expected. The host lowers UTF-8 text to the
+	## active OS representation.
 	from_str : Str -> OsStr
 	from_str = |str| Utf8(str)
 
-	## Create a UTF-8 text OS string.
+	## Create a UTF-8 OS string from a dynamic `Str`.
 	utf8 : Str -> OsStr
 	utf8 = |str| Utf8(str)
 

--- a/platform/Path.roc
+++ b/platform/Path.roc
@@ -91,6 +91,33 @@ Path := [
 			.map_ok(path_type_from_host)
 	}
 
+	## Make a path absolute without requiring it to exist. This does not resolve symlinks.
+	absolute! : Path => Try(Path, [PathErr(IOErr, Path), ..])
+	absolute! = |path| Host.path_absolute!(to_raw(path)).map_ok(from_raw).map_err(|err| PathErr(err, path))
+
+	## Resolve an existing path, including symbolic links, to its absolute native path.
+	canonicalize! : Path => Try(Path, [PathErr(IOErr, Path), ..])
+	canonicalize! = |path| Host.path_canonicalize!(to_raw(path)).map_ok(from_raw).map_err(|err| PathErr(err, path))
+
+	## Copy a regular file and its permissions, replacing the destination file.
+	## Rejects same-file copies (including hard-link aliases) and special files.
+	copy! : Path, Path => Try({}, [CopyErr({ operation : Str, source : Path, destination : Path, error : IOErr }), ..])
+	copy! = |source, destination|
+		Host.path_copy!(to_raw(source), to_raw(destination)).map_err(copy_error)
+
+	## Copy a directory tree into a new destination, following symbolic links.
+	## Missing destination parent directories are created.
+	## Permissions are preserved; timestamps, ownership, ACLs and other metadata are not.
+	## Errors may leave a partial destination. Cycles and overlapping source/destination trees are rejected.
+	copy_dir! : Path, Path => Try({}, [CopyErr({ operation : Str, source : Path, destination : Path, error : IOErr }), ..])
+	copy_dir! = |source, destination| copy_dir_with!(source, destination, { symlinks: Follow, destination: RequireNew })
+
+	## Choose whether to preserve links and whether to merge an existing destination tree.
+	## Merge replaces regular files. Existing destination directory symlinks are rejected.
+	copy_dir_with! : Path, Path, { symlinks : [Follow, Preserve], destination : [RequireNew, Merge] } => Try({}, [CopyErr({ operation : Str, source : Path, destination : Path, error : IOErr }), ..])
+	copy_dir_with! = |source, destination, options|
+		Host.path_copy_dir!(to_raw(source), to_raw(destination), options).map_err(copy_error)
+
 	## Read all bytes from a file at this path.
 	read_bytes! : Path => Try(List(U8), [PathErr(IOErr, Path), ..])
 	read_bytes! = |path| map_file_result(Host.file_read_bytes!(to_raw(path)), path)
@@ -731,3 +758,6 @@ expect {
 		Err(_) => Bool.False
 	}
 }
+
+copy_error : Host.CopyFailure -> [CopyErr({ operation : Str, source : Path, destination : Path, error : IOErr }), ..]
+copy_error = |failure| CopyErr({ operation: failure.operation, source: Path.from_raw(failure.source), destination: Path.from_raw(failure.destination), error: failure.error })

--- a/platform/Path.roc
+++ b/platform/Path.roc
@@ -14,6 +14,16 @@ path_type_from_host = |path_type|
 ## Construct and operate on byte-preserving paths. Native Unix
 ## bytes and Windows UTF-16 units are preserved across host effects; use
 ## `display` only when a lossy human-readable representation is appropriate.
+##
+## Quoted literals create UTF-8 paths, and `join` appends one path component:
+##
+## ```roc
+## config_dir : Path
+## config_dir = "config"
+## Path.create_all!(config_dir)?
+## config_file = Path.join(config_dir, "app.json")
+## Path.write_utf8!(config_file, "{}")?
+## ```
 Path := [
 	Utf8(Str),
 	Unix(List(U8)),

--- a/platform/Path.roc
+++ b/platform/Path.roc
@@ -18,10 +18,8 @@ path_type_from_host = |path_type|
 ## Quoted literals create UTF-8 paths, and `join` appends one path component:
 ##
 ## ```roc
-## config_dir : Path
-## config_dir = "config"
-## Path.create_all!(config_dir)?
-## config_file = Path.join(config_dir, "app.json")
+## Path.create_all!("config")?
+## config_file = Path.join("config", "app.json")
 ## Path.write_utf8!(config_file, "{}")?
 ## ```
 Path := [
@@ -228,7 +226,8 @@ Path := [
 			Err(DirErr(err)) => Err(PathErr(err, path))
 		}
 
-	## Create a UTF-8 text path.
+	## Create a UTF-8 path from a dynamic `Str`. String literals can be used
+	## directly wherever a `Path` is expected.
 	utf8 : Str -> Path
 	utf8 = |str| Utf8(str)
 

--- a/platform/Sqlite.roc
+++ b/platform/Sqlite.roc
@@ -18,6 +18,15 @@ import Path
 ## Database paths use basic-cli's byte-preserving `Path` type.
 ## See the [host runtime behavior](https://github.com/roc-lang/basic-cli#host-runtime-behavior)
 ## for connection caching and lifetime details.
+##
+## ```roc
+## names = Sqlite.query_many!({
+## 	path: "people.db",
+## 	query: "SELECT name FROM people WHERE active = :active",
+## 	bindings: [{ name: ":active", value: Integer(1) }],
+## 	rows: Sqlite.str("name"),
+## })?
+## ```
 Sqlite :: [].{
 
 	## A value accepted by a SQLite binding or returned from a column.

--- a/platform/Tcp.roc
+++ b/platform/Tcp.roc
@@ -9,6 +9,12 @@ import Host
 ## including every underlying read/write attempt. A zero timeout fails
 ## immediately. Read and write timeouts are returned as
 ## `TcpReadErr(TimedOut)` and `TcpWriteErr(TimedOut)` respectively.
+##
+## ```roc
+## stream = Tcp.connect!("example.com", 80, 5_000)?
+## stream.write_utf8!("GET / HTTP/1.0\r\nHost: example.com\r\n\r\n", 5_000)?
+## status_line = stream.read_line!(1_024, 5_000)?
+## ```
 Tcp :: [].{
 
 	## A listening socket. Final ARC release closes it; close! affects all aliases.

--- a/platform/Tcp.roc
+++ b/platform/Tcp.roc
@@ -11,6 +11,35 @@ import Host
 ## `TcpReadErr(TimedOut)` and `TcpWriteErr(TimedOut)` respectively.
 Tcp :: [].{
 
+	## A listening socket. Final ARC release closes it; close! affects all aliases.
+	Listener :: { host : Host.TcpListener }.{
+		to_inspect : Listener -> Str
+		to_inspect = |_| "Tcp.Listener(<opaque>)"
+
+		## Read the reserved local port.
+		local_port! : Listener => Try(U16, _)
+		local_port! = |listener| Host.tcp_local_port!(listener.host).map_err(parse_listener_err)
+
+		## Accept a connection within the given whole-operation timeout.
+		accept! : Listener, U64 => Try(Stream, _)
+		accept! = |listener, timeout_ms|
+			Host.tcp_accept!(listener.host, timeout_ms)
+				.map_ok(|host| Stream.{ host })
+				.map_err(parse_listener_err)
+
+		## Close the listener. Repeated closes succeed.
+		close! : Listener => Try({}, _)
+		close! = |listener| Host.tcp_listener_close!(listener.host).map_err(parse_listener_err)
+	}
+
+	## Bind an address and listen. Port zero reserves an OS-assigned port until
+	## this listener is closed. The timeout includes hostname resolution.
+	listen! : Str, U16, U64 => Try(Listener, _)
+	listen! = |host, port, timeout_ms|
+		Host.tcp_listen!(host, port, timeout_ms)
+			.map_ok(|host_handle| Listener.{ host: host_handle })
+			.map_err(parse_listener_err)
+
 	## Represents a TCP stream.
 	##
 	## The connection is automatically closed when the last reference to the
@@ -172,3 +201,9 @@ parse_stream_err = |err|
 expect parse_connect_err("ErrorKind::TimedOut") == TimedOut
 
 expect parse_stream_err("ErrorKind::TimedOut") == TimedOut
+
+parse_listener_err = |err|
+	match err {
+		"ListenerClosed" => ListenerClosed
+		_ => TcpListenErr(parse_connect_err(err))
+	}

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -4,7 +4,7 @@ platform ""
 	requires {
 		main! : List([Utf8(Str), UnixBytes(List(U8)), WindowsU16s(List(U16))]) => Try({}, [Exit(I32), ..])
 	}
-	exposes [Cmd, Env, File, Http, IOErr, Locale, OsStr, Path, Random, Sleep, Sqlite, Stdin, Stdout, Stderr, Tcp, Tty, Url, Utc]
+	exposes [Cmd, Env, File, Http, IOErr, Locale, Monotonic, OsStr, Path, Random, Sleep, Sqlite, Stdin, Stdout, Stderr, Tcp, Tty, Url, Utc]
 	packages {
 		# HTTP data types (Method, Request, Response) come from the shared
 		# roc-lang/http package so apps and other packages using it see the same
@@ -80,6 +80,26 @@ platform ""
 		"hosted_env_platform": Host.env_platform!,
 		"hosted_env_dict": Host.env_dict!,
 		"hosted_env_set_cwd": Host.env_set_cwd!,
+		"hosted_path_copy": Host.path_copy!,
+		"hosted_path_copy_dir": Host.path_copy_dir!,
+		"hosted_path_absolute": Host.path_absolute!,
+		"hosted_path_canonicalize": Host.path_canonicalize!,
+		"hosted_env_create_temp_dir": Host.env_create_temp_dir!,
+		"hosted_monotonic_now": Host.monotonic_now!,
+		"hosted_cmd_spawn": Host.cmd_spawn!,
+		"hosted_cmd_run": Host.cmd_run!,
+		"hosted_child_pid": Host.child_pid!,
+		"hosted_child_wait": Host.child_wait!,
+		"hosted_child_try_wait": Host.child_try_wait!,
+		"hosted_child_kill": Host.child_kill!,
+		"hosted_child_close": Host.child_close!,
+		"hosted_child_close_stdin": Host.child_close_stdin!,
+		"hosted_child_write": Host.child_write!,
+		"hosted_child_read": Host.child_read!,
+		"hosted_tcp_listen": Host.tcp_listen!,
+		"hosted_tcp_local_port": Host.tcp_local_port!,
+		"hosted_tcp_accept": Host.tcp_accept!,
+		"hosted_tcp_listener_close": Host.tcp_listener_close!,
 	}
 	targets: {
 		inputs_dir: "targets/",
@@ -98,6 +118,7 @@ import Http
 import IOErr
 import InternalSqlite
 import Locale
+import Monotonic
 import OsStr
 import Path
 import Random

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -181,7 +181,7 @@ class BundleServer:
 
 
 def expand(value: str, source: Path) -> str:
-    return value.format(root=ROOT, source=source, source_dir=source.parent)
+    return value.format(root=ROOT, source=source, source_dir=source.parent, python=sys.executable)
 
 
 def wait_for_port(port: int, process: subprocess.Popen[bytes], timeout: float = 5) -> None:

--- a/scripts/test_resource_lifetimes.py
+++ b/scripts/test_resource_lifetimes.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Check Roc/host ownership with a Valgrind-visible glibc diagnostic platform.
+
+The published Linux platform remains static musl. Its allocator is invisible to
+Memcheck, so zero reported allocations cannot validate reference-count cleanup.
+This Linux x86_64-only check builds an isolated glibc copy under ignored target/.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import platform
+import re
+import shutil
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(*args: str, cwd: Path = ROOT) -> subprocess.CompletedProcess[str]:
+    print("+", *args, flush=True)
+    return subprocess.run(args, cwd=cwd, text=True, check=True)
+
+
+def main() -> None:
+    if platform.system() != "Linux" or platform.machine() != "x86_64":
+        raise SystemExit("This diagnostic requires x86_64 Linux with glibc")
+    if not shutil.which("valgrind"):
+        raise SystemExit("Install Valgrind to run the resource-lifetime diagnostic")
+    roc = os.environ.get("ROC", "roc")
+    work = ROOT / "target" / "resource-lifetimes-glibc"
+    pf = work / "platform"
+    inputs = pf / "targets" / "x64glibc"
+    inputs.mkdir(parents=True, exist_ok=True)
+    for source in (ROOT / "platform").glob("*.roc"):
+        shutil.copy2(source, pf / source.name)
+    main_path = pf / "main.roc"
+    main_path.write_text(main_path.read_text().replace(
+        'inputs_dir: "targets/",',
+        'inputs_dir: "targets/",\n'
+        '        x64glibc: { inputs: ["Scrt1.o", "crti.o", "libhost.a", app, '
+        '"crtn.o", "libc.so", "libgcc_s.so.1", "libm.so.6"] },',
+    ))
+    for name in ("Scrt1.o", "crti.o", "crtn.o", "libc.so", "libgcc_s.so.1", "libm.so.6"):
+        source = Path("/usr/lib/x86_64-linux-gnu") / name
+        if not source.is_file():
+            raise SystemExit(f"Missing glibc development input: {source}")
+        shutil.copy2(source, inputs / name)
+    run("cargo", "build", "--locked", "--lib", "--target", "x86_64-unknown-linux-gnu")
+    shutil.copy2(ROOT / "target/x86_64-unknown-linux-gnu/debug/libhost.a", inputs / "libhost.a")
+    for name in ("filesystem-tools", "resource-lifetime", "process-control"):
+        source = (ROOT / "tests" / "resource-lifetimes" / f"{name}.roc").read_text()
+        source, replacements = re.subn(r'platform "[^"]+"', 'platform "platform/main.roc"', source, count=1)
+        if replacements != 1:
+            raise SystemExit(f"Missing platform declaration in {name}")
+        app = work / f"{name}.roc"
+        app.write_text(source)
+        binary = work / name
+        run(roc, "build", str(app), "--target=x64glibc", "--debug", "--no-cache", f"--output={binary}")
+        log = work / f"{name}.valgrind.log"
+        run("valgrind", "--error-exitcode=99", "--leak-check=full",
+            "--errors-for-leak-kinds=definite,indirect", "--track-fds=yes",
+            f"--log-file={log}", str(binary), cwd=work)
+        text = log.read_text()
+        if not re.search(r"total heap usage: [1-9][0-9,]* allocs", text):
+            raise SystemExit(f"Valgrind did not observe heap allocations: {log}")
+        print(f"Verified native ownership: {log}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_spec.json
+++ b/scripts/test_spec.json
@@ -443,6 +443,68 @@
           ]
         }
       ]
+    },
+    {
+      "path": "examples/filesystem-tools.roc",
+      "cases": [
+        {
+          "name": "prepare-release",
+          "args": [
+            "{root}/tests/resource-lifetimes",
+            "release"
+          ],
+          "temp_cwd": true,
+          "stdout_contains": [
+            "Release prepared at "
+          ]
+        },
+        {
+          "name": "missing-paths",
+          "exit_code": 1,
+          "contains": [
+            "MissingPaths"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "examples/process-control.roc",
+      "cases": [
+        {
+          "name": "successful-build",
+          "args": [
+            "{python}",
+            "-c",
+            "import sys; print(\"compiling\"); print(\"warning: example\", file=sys.stderr)"
+          ],
+          "stdout_contains": [
+            "compiling",
+            "Build completed successfully"
+          ],
+          "stderr_contains": [
+            "warning: example"
+          ]
+        },
+        {
+          "name": "failed-build",
+          "args": [
+            "{python}",
+            "-c",
+            "raise SystemExit(7)"
+          ],
+          "exit_code": 1,
+          "contains": [
+            "BuildFailed(Exited(7))"
+          ]
+        },
+        {
+          "name": "missing-command",
+          "exit_code": 1,
+          "contains": [
+            "MissingCommand"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -131,6 +131,9 @@ fn take_arg_list(
     let mut first_error = None;
 
     for item in list.as_slice() {
+        // The list owns its elements even when this outer reference is shared
+        // or sliced. Give the consuming converter a separate element reference.
+        unsafe { item.incref(1) };
         match os_string_from_native(*item, roc_host) {
             Ok(value) => values.push(value),
             Err(error) => {
@@ -141,7 +144,7 @@ fn take_arg_list(
         }
     }
 
-    unsafe { list.decref(roc_host) };
+    unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(*list, roc_host) };
 
     match first_error {
         Some(error) => Err(error),
@@ -153,6 +156,7 @@ fn cmd_to_std(cmd: &Cmd, roc_host: &RocHost) -> io::Result<std::process::Command
     let program = os_string_from_native(cmd.program, roc_host);
     let args = take_arg_list(&cmd.args, roc_host);
     let envs = take_arg_list(&cmd.envs, roc_host);
+    let cwd = take_arg_list(&cmd.cwd, roc_host);
 
     let mut std_cmd = std::process::Command::new(program?);
 
@@ -162,6 +166,10 @@ fn cmd_to_std(cmd: &Cmd, roc_host: &RocHost) -> io::Result<std::process::Command
 
     if cmd.clear_envs {
         std_cmd.env_clear();
+    }
+
+    if let Some(cwd) = cwd?.first() {
+        std_cmd.current_dir(cwd);
     }
 
     let envs = envs?;
@@ -231,15 +239,26 @@ fn cmd_output_failed_to_get_exit_code(error: IOErr) -> CmdOutputError {
 #[no_mangle]
 pub extern "C" fn hosted_cmd_host_exec_exit_code(cmd: Cmd) -> CmdExitResult {
     let roc_host = roc_host();
-    let mut std_cmd = match cmd_to_std(&cmd, roc_host) {
+    let std_cmd = match cmd_to_std(&cmd, roc_host) {
         Ok(cmd) => cmd,
-        Err(error) => return try_cmd_exit_err(cmd_io_err_from_io(&error, roc_host)),
+        Err(error) => {
+            unsafe { cmd.stdin_bytes.decref(roc_host) };
+            return try_cmd_exit_err(cmd_io_err_from_io(&error, roc_host));
+        }
     };
 
-    match std_cmd.status() {
-        Ok(status) => match status.code() {
+    let config = command_config(std_cmd, &cmd, false);
+    match crate::process_service::Child::spawn(config).and_then(|child| child.wait()) {
+        Ok(status) => match if status.failure == 0 && status.signal == 0 {
+            Some(status.exit_code)
+        } else {
+            None
+        } {
             Some(code) => try_cmd_exit_ok(code),
-            None => try_cmd_exit_err(cmd_io_err_other("Process was killed by signal", roc_host)),
+            None => try_cmd_exit_err(cmd_io_err_other(
+                incomplete_reason(status.failure),
+                roc_host,
+            )),
         },
         Err(error) => try_cmd_exit_err(cmd_io_err_from_io(&error, roc_host)),
     }
@@ -248,21 +267,27 @@ pub extern "C" fn hosted_cmd_host_exec_exit_code(cmd: Cmd) -> CmdExitResult {
 #[no_mangle]
 pub extern "C" fn hosted_cmd_host_exec_output(cmd: Cmd) -> CmdOutputResult {
     let roc_host = roc_host();
-    let mut std_cmd = match cmd_to_std(&cmd, roc_host) {
+    let std_cmd = match cmd_to_std(&cmd, roc_host) {
         Ok(cmd) => cmd,
         Err(error) => {
+            unsafe { cmd.stdin_bytes.decref(roc_host) };
             return try_cmd_output_err(cmd_output_failed_to_get_exit_code(
                 cmd_output_io_err_from_io(&error, roc_host),
-            ))
+            ));
         }
     };
 
-    match std_cmd.output() {
+    let config = command_config(std_cmd, &cmd, true);
+    match crate::process_service::Child::spawn(config).and_then(|child| child.wait()) {
         Ok(output) => {
             let stdout_bytes = roc_u8_list_from_slice(&output.stdout, roc_host);
             let stderr_bytes = roc_u8_list_from_slice(&output.stderr, roc_host);
 
-            match output.status.code() {
+            match if output.failure == 0 && output.signal == 0 {
+                Some(output.exit_code)
+            } else {
+                None
+            } {
                 Some(0) => try_cmd_output_ok(CmdOutputSuccess {
                     stderr_bytes,
                     stdout_bytes,
@@ -278,7 +303,7 @@ pub extern "C" fn hosted_cmd_host_exec_output(cmd: Cmd) -> CmdOutputResult {
                         stderr_bytes.decref(roc_host);
                     }
                     try_cmd_output_err(cmd_output_failed_to_get_exit_code(cmd_output_io_err_other(
-                        "Process was killed by signal",
+                        incomplete_reason(output.failure),
                         roc_host,
                     )))
                 }
@@ -287,5 +312,357 @@ pub extern "C" fn hosted_cmd_host_exec_output(cmd: Cmd) -> CmdOutputResult {
         Err(error) => try_cmd_output_err(cmd_output_failed_to_get_exit_code(
             cmd_output_io_err_from_io(&error, roc_host),
         )),
+    }
+}
+
+fn incomplete_reason(failure: u8) -> &'static str {
+    match failure {
+        1 => "Process execution timed out",
+        2 => "Process output limit exceeded",
+        _ => "Process was killed by signal",
+    }
+}
+
+fn command_config(
+    command: std::process::Command,
+    cmd: &Cmd,
+    capture_default: bool,
+) -> crate::process_service::Config {
+    let input = cmd.stdin_bytes.as_slice().to_vec();
+    unsafe {
+        cmd.stdin_bytes.decref(roc_host());
+    }
+    crate::process_service::Config {
+        command,
+        stdin_mode: if capture_default && cmd.stdin_mode == 0 {
+            2
+        } else {
+            cmd.stdin_mode
+        },
+        stdout_mode: if capture_default && cmd.stdout_mode == 0 {
+            3
+        } else {
+            cmd.stdout_mode
+        },
+        stderr_mode: if capture_default && cmd.stderr_mode == 0 {
+            3
+        } else {
+            cmd.stderr_mode
+        },
+        input,
+        timeout_ms: cmd.timeout_ms,
+        output_limit: cmd.output_limit as usize,
+        pending_limit: cmd.pending_limit as usize,
+        manage_tree: cmd.manage_tree,
+        merge_stderr: cmd.merge_stderr,
+    }
+}
+
+macro_rules! normalize_command {
+    ($cmd:expr) => {{
+        let cmd = $cmd;
+        Cmd {
+            args: cmd.args,
+            envs: cmd.envs,
+            program: cmd.program,
+            cwd: cmd.cwd,
+            clear_envs: cmd.clear_envs,
+            stdin_mode: cmd.stdin_mode,
+            stdout_mode: cmd.stdout_mode,
+            stderr_mode: cmd.stderr_mode,
+            stdin_bytes: cmd.stdin_bytes,
+            timeout_ms: cmd.timeout_ms,
+            output_limit: cmd.output_limit,
+            pending_limit: cmd.pending_limit,
+            manage_tree: cmd.manage_tree,
+            merge_stderr: cmd.merge_stderr,
+        }
+    }};
+}
+fn managed_spawn(cmd: Cmd, capture_default: bool) -> io::Result<crate::process_service::Child> {
+    let command = match cmd_to_std(&cmd, roc_host()) {
+        Ok(command) => command,
+        Err(err) => {
+            unsafe { cmd.stdin_bytes.decref(roc_host()) };
+            return Err(err);
+        }
+    };
+    crate::process_service::Child::spawn(command_config(command, &cmd, capture_default))
+}
+fn run_output(output: crate::process_service::Output) -> HostCmdRunOk {
+    HostCmdRunOk {
+        exit_code: output.exit_code,
+        signal: output.signal,
+        failure: output.failure,
+        stdout_bytes: roc_u8_list_from_slice(&output.stdout, roc_host()),
+        stderr_bytes: roc_u8_list_from_slice(&output.stderr, roc_host()),
+    }
+}
+fn run_result(result: io::Result<crate::process_service::Output>) -> HostCmdRunResult {
+    match result {
+        Ok(output) => HostCmdRunResult {
+            tag: HostCmdRunResultTag::Ok,
+            payload: HostCmdRunResultPayload {
+                ok: ManuallyDrop::new(run_output(output)),
+            },
+        },
+        Err(err) => HostCmdRunResult {
+            tag: HostCmdRunResultTag::Err,
+            payload: HostCmdRunResultPayload {
+                err: ManuallyDrop::new(cmd_output_io_err_from_io(&err, roc_host())),
+            },
+        },
+    }
+}
+fn unit_result(result: io::Result<()>) -> HostChildCloseResult {
+    match result {
+        Ok(()) => HostChildCloseResult {
+            tag: HostChildCloseResultTag::Ok,
+            payload: HostChildCloseResultPayload { ok: [] },
+        },
+        Err(err) => HostChildCloseResult {
+            tag: HostChildCloseResultTag::Err,
+            payload: HostChildCloseResultPayload {
+                err: ManuallyDrop::new(cmd_output_io_err_from_io(&err, roc_host())),
+            },
+        },
+    }
+}
+fn with_child<T>(handle: *mut u64, f: impl FnOnce(&crate::process_service::Child) -> T) -> T {
+    let result =
+        f(unsafe { crate::resources::resource_ref::<crate::process_service::Child>(handle) });
+    crate::resources::release(handle, roc_host());
+    result
+}
+#[no_mangle]
+pub extern "C" fn hosted_cmd_spawn(cmd: HostCmdSpawnArgs) -> HostCmdSpawnResult {
+    match managed_spawn(normalize_command!(cmd), false) {
+        Ok(child) => HostCmdSpawnResult {
+            tag: HostCmdSpawnResultTag::Ok,
+            payload: HostCmdSpawnResultPayload {
+                ok: ManuallyDrop::new(crate::resources::box_resource(child, roc_host())),
+            },
+        },
+        Err(err) => HostCmdSpawnResult {
+            tag: HostCmdSpawnResultTag::Err,
+            payload: HostCmdSpawnResultPayload {
+                err: ManuallyDrop::new(cmd_output_io_err_from_io(&err, roc_host())),
+            },
+        },
+    }
+}
+#[no_mangle]
+pub extern "C" fn hosted_cmd_run(cmd: HostCmdRunArgs) -> HostCmdRunResult {
+    run_result(managed_spawn(normalize_command!(cmd), true).and_then(|child| child.wait()))
+}
+#[no_mangle]
+pub extern "C" fn hosted_child_pid(handle: *mut u64) -> HostChildPidResult {
+    match with_child(handle, |child| child.pid()) {
+        Ok(pid) => HostChildPidResult {
+            tag: HostChildPidResultTag::Ok,
+            payload: HostChildPidResultPayload {
+                ok: ManuallyDrop::new(pid),
+            },
+        },
+        Err(err) => HostChildPidResult {
+            tag: HostChildPidResultTag::Err,
+            payload: HostChildPidResultPayload {
+                err: ManuallyDrop::new(cmd_output_io_err_from_io(&err, roc_host())),
+            },
+        },
+    }
+}
+#[no_mangle]
+pub extern "C" fn hosted_child_wait(handle: *mut u64) -> HostChildWaitResult {
+    run_result(with_child(handle, |child| child.wait()))
+}
+#[no_mangle]
+pub extern "C" fn hosted_child_try_wait(handle: *mut u64) -> HostChildTryWaitResult {
+    match with_child(handle, |child| child.try_wait()) {
+        Ok(output) => {
+            let values: Vec<_> = output.into_iter().map(run_output).collect();
+            let list = unsafe { RocList::from_slice(&values, roc_host()) };
+            HostChildTryWaitResult {
+                tag: HostChildTryWaitResultTag::Ok,
+                payload: HostChildTryWaitResultPayload {
+                    ok: ManuallyDrop::new(list),
+                },
+            }
+        }
+        Err(err) => HostChildTryWaitResult {
+            tag: HostChildTryWaitResultTag::Err,
+            payload: HostChildTryWaitResultPayload {
+                err: ManuallyDrop::new(cmd_output_io_err_from_io(&err, roc_host())),
+            },
+        },
+    }
+}
+#[no_mangle]
+pub extern "C" fn hosted_child_kill(handle: *mut u64) -> HostChildKillResult {
+    unit_result(with_child(handle, |child| child.kill()))
+}
+#[no_mangle]
+pub extern "C" fn hosted_child_close(handle: *mut u64) -> HostChildCloseResult {
+    unit_result(with_child(handle, |child| child.close()))
+}
+#[no_mangle]
+pub extern "C" fn hosted_child_close_stdin(handle: *mut u64) -> HostChildCloseStdinResult {
+    unit_result(with_child(handle, |child| child.close_stdin()))
+}
+#[no_mangle]
+pub extern "C" fn hosted_child_write(
+    handle: *mut u64,
+    bytes: RocListWith<u8, false>,
+    timeout_ms: u64,
+) -> HostChildWriteResult {
+    let input = bytes.as_slice().to_vec();
+    unsafe { bytes.decref(roc_host()) };
+    unit_result(with_child(handle, |child| child.write(input, timeout_ms)))
+}
+#[no_mangle]
+pub extern "C" fn hosted_child_read(
+    handle: *mut u64,
+    max_bytes: u64,
+    timeout_ms: u64,
+) -> HostChildReadResult {
+    match with_child(handle, |child| child.read(max_bytes as usize, timeout_ms)) {
+        Ok(event) => HostChildReadResult {
+            tag: HostChildReadResultTag::Ok,
+            payload: HostChildReadResultPayload {
+                ok: ManuallyDrop::new(HostChildReadOk {
+                    stream: event.stream,
+                    bytes: roc_u8_list_from_slice(&event.bytes, roc_host()),
+                }),
+            },
+        },
+        Err(err) => HostChildReadResult {
+            tag: HostChildReadResultTag::Err,
+            payload: HostChildReadResultPayload {
+                err: ManuallyDrop::new(cmd_output_io_err_from_io(&err, roc_host())),
+            },
+        },
+    }
+}
+
+#[cfg(test)]
+mod ownership_tests {
+    use super::*;
+    use std::{cell::RefCell, ffi::c_void};
+
+    thread_local! {
+        // Defer actual frees so an ownership regression fails an assertion rather
+        // than relying on reading freed memory to expose the bug.
+        static FREES: RefCell<Vec<(*mut c_void, usize)>> = const { RefCell::new(Vec::new()) };
+    }
+    extern "C" fn defer_free(_: *mut RocHost, ptr: *mut c_void, alignment: usize) {
+        FREES.with(|frees| frees.borrow_mut().push((ptr, alignment)));
+    }
+    fn host() -> RocHost {
+        assert_eq!(free_count(), 0);
+        let mut host = make_roc_host(std::ptr::null_mut());
+        host.roc_dealloc = defer_free;
+        host
+    }
+    fn free_count() -> usize {
+        FREES.with(|frees| frees.borrow().len())
+    }
+    fn finish(mut host: RocHost, expected: usize) {
+        let frees = FREES.with(|frees| std::mem::take(&mut *frees.borrow_mut()));
+        assert_eq!(frees.len(), expected);
+        for (ptr, alignment) in frees {
+            DefaultAllocators::roc_dealloc(&mut host, ptr, alignment);
+        }
+    }
+    fn utf8(value: &str, host: &RocHost) -> NativeOsStr {
+        NativeOsStr {
+            tag: UnixBytesOrUtf8OrWindowsU16sTag::Utf8,
+            payload: UnixBytesOrUtf8OrWindowsU16sPayload {
+                utf8: ManuallyDrop::new(RocStr::from_str(value, host)),
+            },
+        }
+    }
+
+    #[test]
+    fn consuming_shared_argument_list_preserves_nested_strings() {
+        let host = host();
+        let first = "first argument long enough to need a heap allocation";
+        let second = "second argument also needing its own heap allocation";
+        let list =
+            unsafe { RocList::from_slice(&[utf8(first, &host), utf8(second, &host)], &host) };
+        unsafe {
+            list.incref(1);
+        }
+        assert_eq!(take_arg_list(&list, &host).unwrap(), [first, second]);
+        assert_eq!(free_count(), 0, "shared list elements must remain alive");
+        assert_eq!(take_arg_list(&list, &host).unwrap(), [first, second]);
+        finish(host, 3);
+    }
+
+    #[test]
+    fn final_argument_slice_releases_the_entire_backing_allocation() {
+        let host = host();
+        let words = [
+            "hidden prefix is heap allocated too",
+            "visible middle argument needs the heap",
+            "hidden suffix also needs heap storage",
+        ];
+        let values: Vec<_> = words.iter().map(|value| utf8(value, &host)).collect();
+        let list = unsafe { RocList::from_slice(&values, &host) };
+        let slice = RocList {
+            elements: unsafe { list.elements.add(1) },
+            length: 1,
+            capacity_or_alloc_ptr: list.elements as usize | 1,
+        };
+        assert_eq!(take_arg_list(&slice, &host).unwrap(), [words[1]]);
+        finish(host, 4);
+    }
+
+    #[test]
+    fn shared_native_argument_slice_preserves_caller_storage() {
+        let host = host();
+        #[cfg(unix)]
+        let native = NativeOsStr {
+            tag: UnixBytesOrUtf8OrWindowsU16sTag::UnixBytes,
+            payload: UnixBytesOrUtf8OrWindowsU16sPayload {
+                unix_bytes: ManuallyDrop::new(unsafe {
+                    RocListWith::<u8, false>::from_slice(&[255, 42, 128], &host)
+                }),
+            },
+        };
+        #[cfg(windows)]
+        let native = NativeOsStr {
+            tag: UnixBytesOrUtf8OrWindowsU16sTag::WindowsU16s,
+            payload: UnixBytesOrUtf8OrWindowsU16sPayload {
+                windows_u16s: ManuallyDrop::new(unsafe {
+                    RocListWith::<u16, false>::from_slice(&[0xd800, 42, 0xdc00], &host)
+                }),
+            },
+        };
+        let list = unsafe {
+            RocList::from_slice(
+                &[
+                    utf8("hidden string kept by the shared backing list", &host),
+                    native,
+                ],
+                &host,
+            )
+        };
+        unsafe {
+            list.incref(1);
+        }
+        let slice = RocList {
+            elements: unsafe { list.elements.add(1) },
+            length: 1,
+            capacity_or_alloc_ptr: list.elements as usize | 1,
+        };
+        let selected = take_arg_list(&slice, &host).unwrap();
+        assert_eq!(
+            free_count(),
+            0,
+            "a shared slice cannot release any child allocation"
+        );
+        let all = take_arg_list(&list, &host).unwrap();
+        assert_eq!(selected[0], all[1]);
+        finish(host, 3);
     }
 }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,0 +1,596 @@
+//! Native filesystem operations. Paths never pass through a Unicode conversion.
+use std::{
+    collections::HashSet,
+    fs, io,
+    path::{Component, Path, PathBuf},
+};
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CopyOptions {
+    pub preserve_links: bool,
+    pub merge: bool,
+}
+#[derive(Debug)]
+pub(crate) struct CopyError {
+    pub operation: &'static str,
+    pub source: PathBuf,
+    pub destination: PathBuf,
+    pub error: io::Error,
+}
+fn failure(
+    operation: &'static str,
+    source: &Path,
+    destination: &Path,
+    error: io::Error,
+) -> CopyError {
+    CopyError {
+        operation,
+        source: source.into(),
+        destination: destination.into(),
+        error,
+    }
+}
+fn invalid(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message)
+}
+
+pub(crate) fn create_temp_dir(parent: &Path, prefix: &str) -> io::Result<PathBuf> {
+    if prefix.contains(['/', '\\', ':', '\0']) || prefix == "." || prefix == ".." {
+        return Err(invalid(
+            "temporary directory prefix must be a filename component",
+        ));
+    }
+    let mut builder = tempfile::Builder::new();
+    builder.prefix(prefix);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        builder.permissions(fs::Permissions::from_mode(0o700));
+    }
+    Ok(builder.tempdir_in(parent)?.keep())
+}
+
+// Resolve existing ancestors, including links, without requiring the leaf to exist.
+fn prospective_canonical(path: &Path) -> io::Result<PathBuf> {
+    match fs::canonicalize(path) {
+        Ok(path) => Ok(path),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            let absolute = std::path::absolute(path)?;
+            let mut resolved = PathBuf::new();
+            for component in absolute.components() {
+                match component {
+                    Component::ParentDir => {
+                        resolved.pop();
+                    }
+                    Component::CurDir => {}
+                    other => {
+                        resolved.push(other.as_os_str());
+                        match fs::canonicalize(&resolved) {
+                            Ok(real) => resolved = real,
+                            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                            Err(e) => return Err(e),
+                        }
+                    }
+                }
+            }
+            Ok(resolved)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+pub(crate) fn copy_file(source: &Path, destination: &Path) -> Result<(), CopyError> {
+    let run = || -> io::Result<()> {
+        if !fs::metadata(source)?.is_file() {
+            return Err(invalid("source is not a regular file"));
+        }
+        match fs::metadata(destination) {
+            Ok(metadata) => {
+                if !metadata.is_file() {
+                    return Err(invalid("destination is not a regular file"));
+                }
+                if same_file::is_same_file(source, destination)? {
+                    return Err(invalid("source and destination identify the same file"));
+                }
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+        fs::copy(source, destination)?;
+        Ok(())
+    };
+    run().map_err(|e| failure("copy_file", source, destination, e))
+}
+
+pub(crate) fn copy_dir(
+    source: &Path,
+    destination: &Path,
+    options: CopyOptions,
+) -> Result<(), CopyError> {
+    let src =
+        fs::canonicalize(source).map_err(|e| failure("resolve_source", source, destination, e))?;
+    let dst = prospective_canonical(destination)
+        .map_err(|e| failure("resolve_destination", source, destination, e))?;
+    if dst.starts_with(&src) || src.starts_with(&dst) {
+        return Err(failure(
+            "copy_dir",
+            source,
+            destination,
+            invalid("source and destination trees overlap"),
+        ));
+    }
+    copy_tree(source, destination, options, &mut HashSet::new())
+}
+
+fn copy_tree(
+    source: &Path,
+    destination: &Path,
+    options: CopyOptions,
+    ancestors: &mut HashSet<PathBuf>,
+) -> Result<(), CopyError> {
+    let resolved =
+        fs::canonicalize(source).map_err(|e| failure("resolve_source", source, destination, e))?;
+    let resolved_destination = prospective_canonical(destination)
+        .map_err(|e| failure("resolve_destination", source, destination, e))?;
+    if resolved_destination.starts_with(&resolved) {
+        return Err(failure(
+            "copy_dir",
+            source,
+            destination,
+            invalid("destination is inside source"),
+        ));
+    }
+    if !ancestors.insert(resolved.clone()) {
+        return Err(failure(
+            "copy_dir",
+            source,
+            destination,
+            invalid("symbolic link cycle"),
+        ));
+    }
+    let result = (|| {
+        let metadata =
+            fs::metadata(source).map_err(|e| failure("metadata", source, destination, e))?;
+        if !metadata.is_dir() {
+            return Err(failure(
+                "copy_dir",
+                source,
+                destination,
+                io::Error::from(io::ErrorKind::NotADirectory),
+            ));
+        }
+        if let Some(parent) = destination
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent)
+                .map_err(|e| failure("create_parent_dirs", source, destination, e))?;
+        }
+        match fs::create_dir(destination) {
+            Ok(()) => {}
+            Err(e) if options.merge && e.kind() == io::ErrorKind::AlreadyExists => {
+                let dst = fs::symlink_metadata(destination)
+                    .map_err(|e| failure("metadata", source, destination, e))?;
+                if !dst.is_dir() {
+                    return Err(failure(
+                        "create_dir",
+                        source,
+                        destination,
+                        io::Error::from(io::ErrorKind::NotADirectory),
+                    ));
+                }
+            }
+            Err(e) => return Err(failure("create_dir", source, destination, e)),
+        }
+        let entries =
+            fs::read_dir(source).map_err(|e| failure("read_dir", source, destination, e))?;
+        for entry in entries {
+            let entry = entry.map_err(|e| failure("read_dir_entry", source, destination, e))?;
+            let src = entry.path();
+            let dst = destination.join(entry.file_name());
+            let metadata =
+                fs::symlink_metadata(&src).map_err(|e| failure("metadata", &src, &dst, e))?;
+            if metadata.is_symlink() && options.preserve_links {
+                copy_link(&src, &dst).map_err(|e| failure("copy_symlink", &src, &dst, e))?;
+            } else {
+                let metadata =
+                    fs::metadata(&src).map_err(|e| failure("metadata", &src, &dst, e))?;
+                if metadata.is_dir() {
+                    copy_tree(&src, &dst, options, ancestors)?;
+                } else {
+                    copy_file(&src, &dst)?;
+                }
+            }
+        }
+        fs::set_permissions(destination, metadata.permissions())
+            .map_err(|e| failure("set_permissions", source, destination, e))
+    })();
+    ancestors.remove(&resolved);
+    result
+}
+
+fn copy_link(source: &Path, destination: &Path) -> io::Result<()> {
+    let target = fs::read_link(source)?;
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(target, destination)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::{symlink_dir, symlink_file, FileTypeExt};
+        if fs::symlink_metadata(source)?.file_type().is_symlink_dir() {
+            symlink_dir(target, destination)
+        } else {
+            symlink_file(target, destination)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const DEFAULT: CopyOptions = CopyOptions {
+        preserve_links: false,
+        merge: false,
+    };
+    #[test]
+    fn copy_bytes_modes_and_merge() {
+        let temp = tempfile::tempdir().unwrap();
+        let src = temp.path().join("src");
+        let dst = temp.path().join("dst");
+        fs::create_dir(&src).unwrap();
+        fs::write(src.join("file"), vec![255; 131073]).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(src.join("file"), fs::Permissions::from_mode(0o751)).unwrap();
+        }
+        copy_dir(&src, &dst, DEFAULT).unwrap();
+        assert_eq!(fs::read(dst.join("file")).unwrap(), vec![255; 131073]);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(dst.join("file")).unwrap().permissions().mode() & 0o777,
+                0o751
+            );
+        }
+        assert!(copy_dir(&src, &dst, DEFAULT).is_err());
+        copy_dir(
+            &src,
+            &dst,
+            CopyOptions {
+                merge: true,
+                ..DEFAULT
+            },
+        )
+        .unwrap();
+        assert!(copy_dir(&src, &src.join("nested"), DEFAULT).is_err());
+        fs::hard_link(src.join("file"), temp.path().join("alias")).unwrap();
+        assert!(copy_file(&src.join("file"), &temp.path().join("alias")).is_err());
+        assert_eq!(fs::metadata(src.join("file")).unwrap().len(), 131073);
+    }
+    #[test]
+    fn merge_cannot_write_back_into_source() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        fs::create_dir_all(source.join("source")).unwrap();
+        fs::write(source.join("source/file"), b"original").unwrap();
+        assert!(copy_dir(
+            &source,
+            root.path(),
+            CopyOptions {
+                merge: true,
+                ..DEFAULT
+            }
+        )
+        .is_err());
+        assert_eq!(fs::read(source.join("source/file")).unwrap(), b"original");
+    }
+    #[test]
+    fn copy_tree_creates_missing_destination_parents() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        fs::create_dir(&source).unwrap();
+        fs::write(source.join("file"), b"data").unwrap();
+        let destination = root.path().join("missing/parents/copy");
+        copy_dir(&source, &destination, DEFAULT).unwrap();
+        assert_eq!(fs::read(destination.join("file")).unwrap(), b"data");
+    }
+    #[test]
+    fn temporary_names_permissions_and_cleanup() {
+        let parent = tempfile::tempdir().unwrap();
+        let a = create_temp_dir(parent.path(), "roc-").unwrap();
+        let b = create_temp_dir(parent.path(), "roc-").unwrap();
+        assert_ne!(a, b);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&a).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+        }
+        for bad in ["../escape", "a/b", "a\\b", "C:escape", "..", "\0"] {
+            assert!(create_temp_dir(parent.path(), bad).is_err());
+        }
+    }
+    #[cfg(unix)]
+    #[test]
+    fn links_cycles_and_native_names() {
+        use std::os::unix::{ffi::OsStrExt, fs::symlink};
+        let temp = tempfile::tempdir().unwrap();
+        let src = temp.path().join("src");
+        fs::create_dir(&src).unwrap();
+        let name = std::ffi::OsStr::from_bytes(b"raw\xff");
+        fs::write(src.join(name), b"hello").unwrap();
+        symlink("missing", src.join("dangling")).unwrap();
+        let dst = temp.path().join("preserved");
+        copy_dir(
+            &src,
+            &dst,
+            CopyOptions {
+                preserve_links: true,
+                ..DEFAULT
+            },
+        )
+        .unwrap();
+        assert_eq!(fs::read(dst.join(name)).unwrap(), b"hello");
+        assert_eq!(
+            fs::read_link(dst.join("dangling")).unwrap(),
+            Path::new("missing")
+        );
+        assert!(copy_dir(&src, &temp.path().join("follow"), DEFAULT).is_err());
+        fs::remove_file(src.join("dangling")).unwrap();
+        symlink(".", src.join("cycle")).unwrap();
+        assert!(copy_dir(&src, &temp.path().join("cycle"), DEFAULT).is_err());
+        symlink(&src, temp.path().join("alias")).unwrap();
+        assert!(copy_dir(&src, &temp.path().join("alias/new"), DEFAULT).is_err());
+    }
+}
+
+#[cfg(all(test, unix))]
+mod unix_tests {
+    use super::*;
+    use std::{ffi::CString, os::unix::ffi::OsStrExt};
+    #[test]
+    fn special_files_are_rejected_without_blocking() {
+        let root = tempfile::tempdir().unwrap();
+        let fifo = root.path().join("fifo");
+        let cpath = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(cpath.as_ptr(), 0o600) }, 0);
+        assert!(copy_file(&fifo, &root.path().join("copy")).is_err());
+        let file = root.path().join("file");
+        fs::write(&file, b"safe").unwrap();
+        assert!(copy_file(&file, &fifo).is_err());
+    }
+    #[test]
+    fn directory_permissions_are_applied_after_children() {
+        use std::os::unix::fs::PermissionsExt;
+        let root = tempfile::tempdir().unwrap();
+        let src = root.path().join("source");
+        let dst = root.path().join("destination");
+        fs::create_dir_all(src.join("nested")).unwrap();
+        fs::write(src.join("nested/file"), b"ok").unwrap();
+        fs::set_permissions(src.join("nested"), fs::Permissions::from_mode(0o500)).unwrap();
+        copy_dir(
+            &src,
+            &dst,
+            CopyOptions {
+                preserve_links: false,
+                merge: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(fs::read(dst.join("nested/file")).unwrap(), b"ok");
+        assert_eq!(
+            fs::metadata(dst.join("nested"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o500
+        );
+        for path in [src.join("nested"), dst.join("nested")] {
+            fs::set_permissions(path, fs::Permissions::from_mode(0o700)).unwrap();
+        }
+    }
+    #[test]
+    fn external_links_follow_and_preserve_with_merge_conflicts() {
+        use std::os::unix::fs::symlink;
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let external = root.path().join("external");
+        fs::create_dir(&source).unwrap();
+        fs::create_dir(&external).unwrap();
+        fs::write(external.join("data"), b"external").unwrap();
+        symlink(&external, source.join("link")).unwrap();
+        let followed = root.path().join("followed");
+        copy_dir(
+            &source,
+            &followed,
+            CopyOptions {
+                preserve_links: false,
+                merge: false,
+            },
+        )
+        .unwrap();
+        assert!(!fs::symlink_metadata(followed.join("link"))
+            .unwrap()
+            .is_symlink());
+        assert_eq!(fs::read(followed.join("link/data")).unwrap(), b"external");
+        let preserved = root.path().join("preserved");
+        fs::create_dir(&preserved).unwrap();
+        copy_dir(
+            &source,
+            &preserved,
+            CopyOptions {
+                preserve_links: true,
+                merge: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(fs::read_link(preserved.join("link")).unwrap(), external);
+        let err = copy_dir(
+            &source,
+            &preserved,
+            CopyOptions {
+                preserve_links: true,
+                merge: true,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err.operation, "copy_symlink");
+        assert_eq!(err.error.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(err.source, source.join("link"));
+        assert_eq!(err.destination, preserved.join("link"));
+        assert!(copy_dir(
+            &source,
+            &preserved,
+            CopyOptions {
+                preserve_links: false,
+                merge: true
+            }
+        )
+        .is_err());
+    }
+    #[test]
+    fn concurrent_temporary_directories_are_unique() {
+        let root = tempfile::tempdir().unwrap();
+        let paths = std::thread::scope(|scope| {
+            let threads: Vec<_> = (0..24)
+                .map(|_| scope.spawn(|| create_temp_dir(root.path(), "same-").unwrap()))
+                .collect();
+            threads
+                .into_iter()
+                .map(|thread| thread.join().unwrap())
+                .collect::<HashSet<_>>()
+        });
+        assert_eq!(paths.len(), 24);
+    }
+}
+
+// Hosted adapters own each incoming Roc value and release it after conversion.
+use crate::roc_platform_abi::*;
+use crate::{dir_io_err_from_io, native_path_from_path, path_from_native, roc_host};
+use core::mem::ManuallyDrop;
+
+fn copy_result(result: Result<(), CopyError>) -> HostPathCopyResult {
+    match result {
+        Ok(()) => HostPathCopyResult {
+            tag: HostPathCopyResultTag::Ok,
+            payload: HostPathCopyResultPayload { ok: [] },
+        },
+        Err(error) => copy_failure_result(HostPathCopyErr {
+            operation: RocStr::from_str(error.operation, roc_host()),
+            source: native_path_from_path(&error.source, roc_host()),
+            destination: native_path_from_path(&error.destination, roc_host()),
+            error: dir_io_err_from_io(&error.error, roc_host()),
+        }),
+    }
+}
+fn copy_failure_result(error: HostPathCopyErr) -> HostPathCopyResult {
+    HostPathCopyResult {
+        tag: HostPathCopyResultTag::Err,
+        payload: HostPathCopyResultPayload {
+            err: ManuallyDrop::new(error),
+        },
+    }
+}
+fn decode_copy_paths(
+    source: UnixBytesOrUtf8OrWindowsU16s,
+    destination: UnixBytesOrUtf8OrWindowsU16s,
+) -> Result<(PathBuf, PathBuf), HostPathCopyErr> {
+    // Retain the originals for errors such as an unsupported native representation.
+    unsafe {
+        source.incref(1);
+        destination.incref(1);
+    }
+    let source_path = path_from_native(source, roc_host());
+    let destination_path = path_from_native(destination, roc_host());
+    match (source_path, destination_path) {
+        (Ok(src), Ok(dst)) => {
+            unsafe {
+                source.decref(roc_host());
+                destination.decref(roc_host());
+            }
+            Ok((src, dst))
+        }
+        (Err(error), _) | (_, Err(error)) => Err(HostPathCopyErr {
+            operation: RocStr::from_str("decode_path", roc_host()),
+            source,
+            destination,
+            error: dir_io_err_from_io(&error, roc_host()),
+        }),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn hosted_path_copy(
+    source: UnixBytesOrUtf8OrWindowsU16s,
+    destination: UnixBytesOrUtf8OrWindowsU16s,
+) -> HostPathCopyResult {
+    match decode_copy_paths(source, destination) {
+        Ok((source, destination)) => copy_result(copy_file(&source, &destination)),
+        Err(error) => copy_failure_result(error),
+    }
+}
+#[no_mangle]
+pub extern "C" fn hosted_path_copy_dir(
+    source: UnixBytesOrUtf8OrWindowsU16s,
+    destination: UnixBytesOrUtf8OrWindowsU16s,
+    options: HostPathCopyDirArg2,
+) -> HostPathCopyDirResult {
+    match decode_copy_paths(source, destination) {
+        Ok((source, destination)) => copy_result(copy_dir(
+            &source,
+            &destination,
+            CopyOptions {
+                preserve_links: matches!(options.symlinks, FollowOrPreserve::Preserve),
+                merge: matches!(options.destination, MergeOrRequireNew::Merge),
+            },
+        )),
+        Err(error) => copy_failure_result(error),
+    }
+}
+
+fn native_path_result(result: io::Result<PathBuf>) -> HostPathAbsoluteResult {
+    match result {
+        Ok(path) => HostPathAbsoluteResult {
+            tag: HostPathAbsoluteResultTag::Ok,
+            payload: HostPathAbsoluteResultPayload {
+                ok: ManuallyDrop::new(native_path_from_path(&path, roc_host())),
+            },
+        },
+        Err(error) => HostPathAbsoluteResult {
+            tag: HostPathAbsoluteResultTag::Err,
+            payload: HostPathAbsoluteResultPayload {
+                err: ManuallyDrop::new(dir_io_err_from_io(&error, roc_host())),
+            },
+        },
+    }
+}
+#[no_mangle]
+pub extern "C" fn hosted_path_absolute(
+    path: UnixBytesOrUtf8OrWindowsU16s,
+) -> HostPathAbsoluteResult {
+    native_path_result(path_from_native(path, roc_host()).and_then(std::path::absolute))
+}
+#[no_mangle]
+pub extern "C" fn hosted_path_canonicalize(
+    path: UnixBytesOrUtf8OrWindowsU16s,
+) -> HostPathCanonicalizeResult {
+    native_path_result(path_from_native(path, roc_host()).and_then(fs::canonicalize))
+}
+#[no_mangle]
+pub extern "C" fn hosted_env_create_temp_dir(
+    parent: UnixBytesOrUtf8OrWindowsU16s,
+    prefix: RocStr,
+) -> HostEnvCreateTempDirResult {
+    let result = path_from_native(parent, roc_host())
+        .and_then(|parent| create_temp_dir(&parent, prefix.as_str()));
+    unsafe {
+        prefix.decref(roc_host());
+    }
+    native_path_result(result)
+}

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -318,12 +318,17 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn links_cycles_and_native_names() {
-        use std::os::unix::{ffi::OsStrExt, fs::symlink};
+        #[cfg(not(target_vendor = "apple"))]
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::symlink;
         let temp = tempfile::tempdir().unwrap();
         let src = temp.path().join("src");
         fs::create_dir(&src).unwrap();
-        let name = std::ffi::OsStr::from_bytes(b"raw\xff");
-        fs::write(src.join(name), b"hello").unwrap();
+        #[cfg(not(target_vendor = "apple"))]
+        {
+            let name = std::ffi::OsStr::from_bytes(b"raw\xff");
+            fs::write(src.join(name), b"hello").unwrap();
+        }
         symlink("missing", src.join("dangling")).unwrap();
         let dst = temp.path().join("preserved");
         copy_dir(
@@ -335,7 +340,11 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(fs::read(dst.join(name)).unwrap(), b"hello");
+        #[cfg(not(target_vendor = "apple"))]
+        assert_eq!(
+            fs::read(dst.join(std::ffi::OsStr::from_bytes(b"raw\xff"))).unwrap(),
+            b"hello"
+        );
         assert_eq!(
             fs::read_link(dst.join("dangling")).unwrap(),
             Path::new("missing")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,12 @@ use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 mod cmd;
 mod http;
 mod roc_platform_abi;
+mod resources;
+mod filesystem;
+mod process_service;
 mod sqlite;
 mod tcp;
+mod listener;
 
 use crate::roc_platform_abi::*;
 
@@ -1209,9 +1213,10 @@ pub extern "C" fn hosted_dir_list(path: UnixBytesOrUtf8OrWindowsU16s) -> HostDir
     };
     match fs::read_dir(&path) {
         Ok(read_dir) => {
-            let entries: Vec<std::path::PathBuf> = read_dir
-                .filter_map(|entry| entry.ok().map(|entry| entry.path()))
-                .collect();
+            let entries = match collect_directory_entries(read_dir.map(|entry| entry.map(|entry| entry.path()))) {
+                Ok(entries) => entries,
+                Err(error) => return try_dir_list_err(dir_io_err_from_io(&error, roc_host)),
+            };
             let list = unsafe {
                 RocList::<UnixBytesOrUtf8OrWindowsU16s>::allocate(entries.len(), roc_host)
             };
@@ -1229,6 +1234,10 @@ pub extern "C" fn hosted_dir_list(path: UnixBytesOrUtf8OrWindowsU16s) -> HostDir
             roc_host,
         )),
     }
+}
+
+fn collect_directory_entries(entries: impl IntoIterator<Item = io::Result<std::path::PathBuf>>) -> io::Result<Vec<std::path::PathBuf>> {
+    entries.into_iter().collect()
 }
 
 #[no_mangle]
@@ -1411,51 +1420,20 @@ pub extern "C" fn hosted_file_read_utf8(path: UnixBytesOrUtf8OrWindowsU16s) -> F
 //
 // The `Host.FileReader` backing `File.Reader` is represented by the generated
 // glue as `*mut u64`: a boxed u64 holding a raw `*mut BufReader<fs::File>`. The box is refcounted
-// with `allocate_box`/`decref_box_with`; closing the file happens in
-// `drop_file_reader` when the last reference is released.
+// through resources::box_resource; allocator finalization closes the file on
+// the last release, including final releases performed by compiled Roc.
 // ----------------------------------------------------------------------------
 
-const FILE_READER_BOX_ALIGN: usize = core::mem::align_of::<u64>();
-
 fn box_file_reader(reader: BufReader<fs::File>, roc_host: &RocHost) -> *mut u64 {
-    let raw: *mut BufReader<fs::File> = Box::into_raw(Box::new(reader));
-    let boxed = unsafe {
-        allocate_box(
-            core::mem::size_of::<u64>(),
-            FILE_READER_BOX_ALIGN,
-            false,
-            roc_host,
-        )
-    };
-    unsafe {
-        *(boxed as *mut u64) = raw as u64;
-    }
-    boxed as *mut u64
+    resources::box_resource(reader, roc_host)
 }
 
 unsafe fn file_reader_ref<'a>(handle: *mut u64) -> &'a mut BufReader<fs::File> {
-    &mut *(*handle as *mut BufReader<fs::File>)
-}
-
-extern "C" fn drop_file_reader(data_ptr: *mut c_void, _roc_host: *mut RocHost) {
-    unsafe {
-        let raw = *(data_ptr as *mut u64) as *mut BufReader<fs::File>;
-        if !raw.is_null() {
-            drop(Box::from_raw(raw));
-        }
-    }
+    unsafe { resources::resource_ref(handle) }
 }
 
 fn release_file_reader(handle: *mut u64, roc_host: &RocHost) {
-    unsafe {
-        decref_box_with(
-            handle as RocBox,
-            FILE_READER_BOX_ALIGN,
-            false,
-            Some(drop_file_reader),
-            roc_host,
-        )
-    };
+    resources::release(handle, roc_host);
 }
 
 #[no_mangle]
@@ -2090,7 +2068,7 @@ pub extern "C" fn roc_alloc(length: usize, alignment: usize) -> *mut c_void {
 
 #[no_mangle]
 pub extern "C" fn roc_dealloc(ptr: *mut c_void, alignment: usize) {
-    DefaultAllocators::roc_dealloc(roc_host_ptr(), ptr, alignment);
+    resources::dealloc(roc_host_ptr(), ptr, alignment);
 }
 
 #[no_mangle]
@@ -2176,11 +2154,18 @@ pub extern "C" fn main(argc: i32, argv: *const *const c_char) -> i32 {
 }
 
 pub fn rust_main(argc: i32, argv: *const *const c_char) -> i32 {
-    let mut roc_host = make_roc_host(core::ptr::null_mut());
+    // Unlike a Rust executable, this C-ABI entrypoint does not pass through
+    // std::rt's signal initialization. Return BrokenPipe from our I/O effects.
+    // std::process restores SIGPIPE's default disposition in spawned children.
+    #[cfg(unix)]
+    unsafe { libc::signal(libc::SIGPIPE, libc::SIG_IGN); }
+    let mut roc_host = resources::make_host();
     set_roc_host(&mut roc_host);
 
     let args_list = build_args_list(argc, argv, &roc_host);
     let mut exit_code = unsafe { roc_main(args_list) };
+
+    process_service::shutdown();
 
     if DEBUG_OR_EXPECT_CALLED.load(Ordering::Acquire) && exit_code == 0 {
         exit_code = 1;
@@ -2190,6 +2175,13 @@ pub fn rust_main(argc: i32, argv: *const *const c_char) -> i32 {
     exit_code
 }
 
+#[no_mangle]
+pub extern "C" fn hosted_monotonic_now() -> u64 {
+    static ORIGIN: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
+    let elapsed = ORIGIN.get_or_init(std::time::Instant::now).elapsed().as_nanos();
+    u64::try_from(elapsed).unwrap_or(u64::MAX)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2197,6 +2189,12 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     static NEXT_TEST_DIR: AtomicUsize = AtomicUsize::new(0);
+
+    #[test]
+    fn directory_iteration_error_is_not_silently_dropped() {
+        let entries = [Ok(PathBuf::from("first")), Err(io::Error::from(io::ErrorKind::PermissionDenied)), Ok(PathBuf::from("last"))];
+        assert_eq!(collect_directory_entries(entries).unwrap_err().kind(), io::ErrorKind::PermissionDenied);
+    }
 
     struct TestDir(PathBuf);
 

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,0 +1,139 @@
+//! Deadline-aware listeners using a host-thread reactor.
+use crate::{roc_host, resources, roc_platform_abi::*};
+use std::{io, mem::ManuallyDrop, net::{TcpListener, TcpStream}, time::Duration};
+
+thread_local! {
+    static RUNTIME: tokio::runtime::Runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all().build().expect("TCP listener runtime");
+}
+struct Listener { socket: Option<tokio::net::TcpListener> }
+
+fn listen(host: String, port: u16, timeout_ms: u64) -> io::Result<Listener> {
+    let deadline = crate::tcp::deadline_from_timeout(timeout_ms)?;
+    let addresses = crate::tcp::resolve_with_deadline(host, port, deadline)?;
+    let mut error = io::Error::from(io::ErrorKind::AddrNotAvailable);
+    for address in addresses {
+        crate::tcp::remaining_time(deadline)?;
+        let result = (|| {
+            let socket = socket2::Socket::new(socket2::Domain::for_address(address), socket2::Type::STREAM, Some(socket2::Protocol::TCP))?;
+            #[cfg(windows)] exclusive_address(&socket)?;
+            socket.bind(&address.into())?;
+            socket.listen(128)?;
+            socket.set_nonblocking(true)?;
+            RUNTIME.with(|runtime| {
+                let _entered = runtime.enter();
+                tokio::net::TcpListener::from_std(TcpListener::from(socket))
+                    .map(|socket| Listener { socket: Some(socket) })
+            })
+        })();
+        match result { Ok(listener) => return Ok(listener), Err(e) => error = e }
+    }
+    Err(error)
+}
+
+#[cfg(windows)]
+fn exclusive_address(socket: &socket2::Socket) -> io::Result<()> {
+    use std::os::windows::io::AsRawSocket;
+    use windows_sys::Win32::Networking::WinSock::{setsockopt, WSAGetLastError, SOL_SOCKET, SO_EXCLUSIVEADDRUSE};
+    let enabled: i32 = 1;
+    let result = unsafe { setsockopt(socket.as_raw_socket() as _, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, (&enabled as *const i32).cast(), size_of::<i32>() as i32) };
+    if result == 0 { Ok(()) } else { Err(io::Error::from_raw_os_error(unsafe { WSAGetLastError() })) }
+}
+
+impl Listener {
+    fn socket(&self) -> io::Result<&tokio::net::TcpListener> {
+        self.socket.as_ref().ok_or_else(|| io::Error::new(io::ErrorKind::NotConnected, "ListenerClosed"))
+    }
+    fn accept(&self, timeout_ms: u64) -> io::Result<TcpStream> {
+        crate::tcp::deadline_from_timeout(timeout_ms)?;
+        let socket = self.socket()?;
+        RUNTIME.with(|runtime| runtime.block_on(async {
+            let (stream, _) = tokio::time::timeout(Duration::from_millis(timeout_ms), socket.accept()).await
+                .map_err(|_| io::Error::from(io::ErrorKind::TimedOut))??;
+            let stream = stream.into_std()?;
+            stream.set_nonblocking(false)?;
+            Ok(stream)
+        }))
+    }
+}
+
+fn error_string(error: io::Error, host: &RocHost) -> RocStr {
+    if error.kind() == io::ErrorKind::NotConnected {
+        RocStr::from_str("ListenerClosed", host)
+    } else { crate::tcp::to_tcp_connect_err(error, host) }
+}
+
+#[no_mangle]
+pub extern "C" fn hosted_tcp_listen(host: RocStr, port: u16, timeout_ms: u64) -> HostTcpListenResult {
+    let roc_host = roc_host();
+    let name = host.as_str().to_owned();
+    unsafe { host.decref(roc_host) };
+    match listen(name, port, timeout_ms) {
+        Ok(listener) => HostTcpListenResult { tag: HostTcpListenResultTag::Ok, payload: HostTcpListenResultPayload { ok: ManuallyDrop::new(resources::box_resource(listener, roc_host)) } },
+        Err(error) => HostTcpListenResult { tag: HostTcpListenResultTag::Err, payload: HostTcpListenResultPayload { err: ManuallyDrop::new(error_string(error, roc_host)) } },
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn hosted_tcp_local_port(handle: *mut u64) -> HostTcpLocalPortResult {
+    let host = roc_host();
+    let listener = unsafe { resources::resource_ref::<Listener>(handle) };
+    let result = match listener.socket().and_then(|socket| socket.local_addr()) {
+        Ok(address) => HostTcpLocalPortResult { tag: HostTcpLocalPortResultTag::Ok, payload: HostTcpLocalPortResultPayload { ok: ManuallyDrop::new(address.port()) } },
+        Err(error) => HostTcpLocalPortResult { tag: HostTcpLocalPortResultTag::Err, payload: HostTcpLocalPortResultPayload { err: ManuallyDrop::new(error_string(error, host)) } },
+    };
+    resources::release(handle, host);
+    result
+}
+
+#[no_mangle]
+pub extern "C" fn hosted_tcp_accept(handle: *mut u64, timeout_ms: u64) -> HostTcpAcceptResult {
+    let host = roc_host();
+    let listener = unsafe { resources::resource_ref::<Listener>(handle) };
+    let result = match listener.accept(timeout_ms) {
+        Ok(stream) => HostTcpAcceptResult { tag: HostTcpAcceptResultTag::Ok, payload: HostTcpAcceptResultPayload { ok: ManuallyDrop::new(crate::tcp::box_tcp_stream(std::io::BufReader::new(stream), host)) } },
+        Err(error) => HostTcpAcceptResult { tag: HostTcpAcceptResultTag::Err, payload: HostTcpAcceptResultPayload { err: ManuallyDrop::new(error_string(error, host)) } },
+    };
+    resources::release(handle, host);
+    result
+}
+
+#[no_mangle]
+pub extern "C" fn hosted_tcp_listener_close(handle: *mut u64) -> HostTcpListenerCloseResult {
+    let host = roc_host();
+    let listener = unsafe { resources::resource_ref::<Listener>(handle) };
+    listener.socket.take();
+    resources::release(handle, host);
+    HostTcpListenerCloseResult { tag: HostTcpListenerCloseResultTag::Ok, payload: HostTcpListenerCloseResultPayload { ok: [] } }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn reserved_port_accept_deadline_and_close() {
+        let mut listener = listen("127.0.0.1".into(), 0, 1000).unwrap();
+        let address = listener.socket().unwrap().local_addr().unwrap();
+        assert_ne!(address.port(), 0);
+        assert!(TcpListener::bind(address).is_err());
+        assert_eq!(listener.accept(10).unwrap_err().kind(), io::ErrorKind::TimedOut);
+        assert_eq!(listener.accept(0).unwrap_err().kind(), io::ErrorKind::TimedOut);
+        let client = TcpStream::connect(address).unwrap();
+        let server = listener.accept(1000).unwrap();
+        drop(client); drop(server);
+        listener.socket.take();
+        assert_eq!(listener.accept(1000).unwrap_err().kind(), io::ErrorKind::NotConnected);
+    }
+    #[test]
+    fn final_arc_release_releases_port() {
+        let host = resources::make_host();
+        let listener = listen("127.0.0.1".into(), 0, 1000).unwrap();
+        let address = listener.socket().unwrap().local_addr().unwrap();
+        let handle = resources::box_resource(listener, &host);
+        unsafe { incref_box(handle.cast(), 1) };
+        resources::release(handle, &host);
+        assert!(TcpListener::bind(address).is_err());
+        resources::release(handle, &host);
+        assert!(TcpListener::bind(address).is_ok());
+    }
+}

--- a/src/process_service.rs
+++ b/src/process_service.rs
@@ -1,0 +1,738 @@
+//! Rust-owned process supervision. No Roc allocations cross the service boundary.
+use process_wrap::tokio::*;
+use std::{
+    collections::VecDeque,
+    io,
+    process::Stdio,
+    sync::{Arc, Condvar, Mutex, OnceLock, Weak},
+    time::{Duration, Instant},
+};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWriteExt},
+    sync::{Mutex as AsyncMutex, Notify},
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct Output {
+    pub exit_code: i32,
+    pub signal: i32,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub failure: u8,
+}
+#[derive(Clone, Debug)]
+pub struct Event {
+    pub stream: u8,
+    pub bytes: Vec<u8>,
+}
+pub struct Config {
+    pub command: std::process::Command,
+    pub stdin_mode: u8,
+    pub stdout_mode: u8,
+    pub stderr_mode: u8,
+    pub input: Vec<u8>,
+    pub timeout_ms: u64,
+    pub output_limit: usize,
+    pub pending_limit: usize,
+    pub manage_tree: bool,
+    pub merge_stderr: bool,
+}
+struct State {
+    output: Output,
+    events: VecDeque<Event>,
+    pending: usize,
+    done: bool,
+    error: Option<(io::ErrorKind, String)>,
+}
+struct Shared {
+    state: Mutex<State>,
+    changed: Condvar,
+    cancel: Notify,
+}
+pub struct Child {
+    pid: u32,
+    shared: Arc<Shared>,
+    stdin: Arc<AsyncMutex<Option<tokio::process::ChildStdin>>>,
+    closed: Mutex<bool>,
+}
+fn registry() -> &'static Mutex<Vec<Weak<Shared>>> {
+    static REGISTRY: OnceLock<Mutex<Vec<Weak<Shared>>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(Vec::new()))
+}
+/// Terminate and reap children before the host exits normally.
+pub fn shutdown() {
+    let children: Vec<_> = registry()
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(Weak::upgrade)
+        .collect();
+    for child in &children {
+        child.cancel.notify_one();
+    }
+    for child in children {
+        let mut state = child.state.lock().unwrap();
+        while !state.done {
+            state = child.changed.wait(state).unwrap();
+        }
+    }
+}
+fn service() -> &'static tokio::runtime::Handle {
+    static HANDLE: OnceLock<tokio::runtime::Handle> = OnceLock::new();
+    HANDLE.get_or_init(|| {
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        std::thread::Builder::new()
+            .name("roc-process-service".into())
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("process runtime");
+                tx.send(runtime.handle().clone()).unwrap();
+                runtime.block_on(std::future::pending::<()>());
+            })
+            .expect("process service thread");
+        rx.recv().unwrap()
+    })
+}
+fn sync_task<T: Send + 'static>(
+    future: impl std::future::Future<Output = T> + Send + 'static,
+) -> T {
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    service().spawn(async move {
+        let value = future.await;
+        let _ = tx.send(value);
+    });
+    rx.recv().expect("process task stopped")
+}
+fn forwarding_slots() -> Arc<tokio::sync::Semaphore> {
+    static SLOTS: OnceLock<Arc<tokio::sync::Semaphore>> = OnceLock::new();
+    SLOTS
+        .get_or_init(|| Arc::new(tokio::sync::Semaphore::new(2)))
+        .clone()
+}
+// A cancelled async waiter does not interrupt an OS write. Keep the permit in
+// the actual blocking closure to bound stranded forwarding work across commands.
+async fn forward_blocking(
+    write: impl FnOnce() -> io::Result<()> + Send + 'static,
+) -> io::Result<()> {
+    let permit = forwarding_slots()
+        .acquire_owned()
+        .await
+        .map_err(io::Error::other)?;
+    tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        write()
+    })
+    .await
+    .map_err(io::Error::other)?
+}
+fn output_stdio(mode: u8) -> Stdio {
+    match mode {
+        2 => Stdio::null(),
+        3..=5 => Stdio::piped(),
+        _ => Stdio::inherit(),
+    }
+}
+fn closed_error() -> io::Error {
+    io::Error::new(io::ErrorKind::BrokenPipe, "Child is closed")
+}
+impl Child {
+    pub fn spawn(config: Config) -> io::Result<Self> {
+        sync_task(async move { spawn(config).await })
+    }
+    fn check_open(&self) -> io::Result<()> {
+        if *self.closed.lock().unwrap() {
+            Err(closed_error())
+        } else {
+            Ok(())
+        }
+    }
+    pub fn pid(&self) -> io::Result<u32> {
+        self.check_open()?;
+        Ok(self.pid)
+    }
+    pub fn wait(&self) -> io::Result<Output> {
+        self.close_stdin()?;
+        let mut state = self.shared.state.lock().unwrap();
+        while !state.done {
+            state = self.shared.changed.wait(state).unwrap();
+        }
+        result(&state)
+    }
+    pub fn try_wait(&self) -> io::Result<Option<Output>> {
+        self.check_open()?;
+        let state = self.shared.state.lock().unwrap();
+        if state.done {
+            result(&state).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+    pub fn kill(&self) -> io::Result<()> {
+        self.check_open()?;
+        self.shared.cancel.notify_one();
+        Ok(())
+    }
+    pub fn close(&self) -> io::Result<()> {
+        let mut closed = self.closed.lock().unwrap();
+        if *closed {
+            return Ok(());
+        }
+        self.shared.cancel.notify_one();
+        let mut state = self.shared.state.lock().unwrap();
+        while !state.done {
+            state = self.shared.changed.wait(state).unwrap();
+        }
+        *closed = true;
+        result(&state).map(|_| ())
+    }
+    pub fn close_stdin(&self) -> io::Result<()> {
+        self.check_open()?;
+        let stdin = self.stdin.clone();
+        sync_task(async move {
+            stdin.lock().await.take();
+        });
+        Ok(())
+    }
+    pub fn write(&self, bytes: Vec<u8>, timeout_ms: u64) -> io::Result<()> {
+        self.check_open()?;
+        let stdin = self.stdin.clone();
+        sync_task(async move {
+            let deadline = tokio::time::Instant::now()
+                .checked_add(Duration::from_millis(timeout_ms))
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Timeout is too large"))?;
+            tokio::time::timeout_at(deadline, async {
+                let mut input = stdin.lock().await;
+                input
+                    .as_mut()
+                    .ok_or_else(closed_error)?
+                    .write_all(&bytes)
+                    .await
+            })
+            .await
+            .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "Child stdin write timed out"))?
+        })
+    }
+    pub fn read(&self, max_bytes: usize, timeout_ms: u64) -> io::Result<Event> {
+        self.check_open()?;
+        if max_bytes == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Read size must be positive",
+            ));
+        }
+        let deadline = Instant::now()
+            .checked_add(Duration::from_millis(timeout_ms))
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Timeout is too large"))?;
+        let mut state = self.shared.state.lock().unwrap();
+        loop {
+            if let Some(mut event) = state.events.pop_front() {
+                if event.bytes.len() > max_bytes {
+                    let rest = event.bytes.split_off(max_bytes);
+                    state.events.push_front(Event {
+                        stream: event.stream,
+                        bytes: rest,
+                    });
+                }
+                state.pending -= event.bytes.len();
+                return Ok(event);
+            }
+            if state.done {
+                if let Some((kind, message)) = &state.error {
+                    return Err(io::Error::new(*kind, message.clone()));
+                }
+                return Ok(Event {
+                    stream: 0,
+                    bytes: Vec::new(),
+                });
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "Child output read timed out",
+                ));
+            }
+            state = self
+                .shared
+                .changed
+                .wait_timeout(state, remaining)
+                .unwrap()
+                .0;
+        }
+    }
+}
+impl Drop for Child {
+    fn drop(&mut self) {
+        self.shared.cancel.notify_one();
+    }
+}
+fn result(state: &State) -> io::Result<Output> {
+    if let Some((kind, message)) = &state.error {
+        Err(io::Error::new(*kind, message.clone()))
+    } else {
+        Ok(state.output.clone())
+    }
+}
+fn report_error(shared: &Shared, error: &io::Error) {
+    shared.state.lock().unwrap().error = Some((error.kind(), error.to_string()));
+    shared.cancel.notify_one();
+    shared.changed.notify_all();
+}
+async fn observed_pump<R: AsyncRead + Unpin>(
+    reader: R,
+    shared: Arc<Shared>,
+    stream: u8,
+    mode: u8,
+    output_limit: usize,
+    pending_limit: usize,
+) -> io::Result<()> {
+    let result = pump(
+        reader,
+        shared.clone(),
+        stream,
+        mode,
+        output_limit,
+        pending_limit,
+    )
+    .await;
+    if let Err(error) = &result {
+        report_error(&shared, error);
+    }
+    result
+}
+async fn pump<R: AsyncRead + Unpin>(
+    mut reader: R,
+    shared: Arc<Shared>,
+    stream: u8,
+    mode: u8,
+    output_limit: usize,
+    pending_limit: usize,
+) -> io::Result<()> {
+    let mut buffer = [0u8; 8192];
+    loop {
+        let count = reader.read(&mut buffer).await?;
+        if count == 0 {
+            return Ok(());
+        }
+        {
+            let mut state = shared.state.lock().unwrap();
+            if mode == 4 {
+                let keep = count.min(pending_limit.saturating_sub(state.pending));
+                if keep != 0 {
+                    state.events.push_back(Event {
+                        stream,
+                        bytes: buffer[..keep].to_vec(),
+                    });
+                    state.pending += keep;
+                }
+                if keep != count {
+                    state.output.failure = 2;
+                    shared.cancel.notify_one();
+                }
+            } else if mode == 3 || mode == 5 {
+                let used = state.output.stdout.len() + state.output.stderr.len();
+                let keep = count.min(output_limit.saturating_sub(used));
+                if stream == 1 {
+                    state.output.stdout.extend_from_slice(&buffer[..keep]);
+                } else {
+                    state.output.stderr.extend_from_slice(&buffer[..keep]);
+                }
+                if keep != count {
+                    state.output.failure = 2;
+                    shared.cancel.notify_one();
+                }
+            }
+            shared.changed.notify_all();
+        }
+        if mode == 5 || mode == 1 || mode == 0 {
+            // Blocking terminal writes run outside the service thread.
+            let bytes = buffer[..count].to_vec();
+            forward_blocking(move || {
+                use std::io::Write;
+                if stream == 1 {
+                    std::io::stdout().write_all(&bytes)
+                } else {
+                    std::io::stderr().write_all(&bytes)
+                }
+            })
+            .await?;
+        }
+    }
+}
+async fn spawn(mut config: Config) -> io::Result<Child> {
+    let deadline = if config.timeout_ms == 0 {
+        None
+    } else {
+        Some(tokio::time::Instant::now()
+            .checked_add(Duration::from_millis(config.timeout_ms))
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Timeout is too large"))?)
+    };
+    config.command.stdin(match config.stdin_mode {
+        2 => Stdio::null(),
+        3 | 4 => Stdio::piped(),
+        _ => Stdio::inherit(),
+    });
+    config.command.stdout(output_stdio(config.stdout_mode));
+    config.command.stderr(output_stdio(config.stderr_mode));
+    // Both descriptors share one kernel pipe, preserving their actual write ordering.
+    let merged = if config.merge_stderr && config.stdout_mode != 2 {
+        let (reader, writer) = std::io::pipe()?;
+        config.command.stdout(Stdio::from(writer.try_clone()?));
+        config.command.stderr(Stdio::from(writer));
+        #[cfg(unix)]
+        let reader = std::process::ChildStdout::from(std::os::fd::OwnedFd::from(reader));
+        #[cfg(windows)]
+        let reader =
+            std::process::ChildStdout::from(std::os::windows::io::OwnedHandle::from(reader));
+        Some(tokio::process::ChildStdout::from_std(reader)?)
+    } else {
+        if config.merge_stderr {
+            config.command.stderr(Stdio::null());
+        }
+        None
+    };
+    let mut command = CommandWrap::from(tokio::process::Command::from(config.command));
+    command.wrap(KillOnDrop);
+    if config.manage_tree {
+        #[cfg(unix)]
+        command.wrap(ProcessGroup::leader());
+        #[cfg(windows)]
+        command.wrap(JobObject);
+    }
+    let mut child = command.spawn()?;
+    let pid = child
+        .id()
+        .ok_or_else(|| io::Error::other("Child has no process ID"))?;
+    let stdout = merged.or_else(|| child.stdout().take());
+    let stderr = child.stderr().take();
+    let mut input_pipe = child.stdin().take();
+    let automatic_input = if config.stdin_mode == 3 {
+        input_pipe.take()
+    } else {
+        None
+    };
+    let stdin = Arc::new(AsyncMutex::new(input_pipe));
+    let shared = Arc::new(Shared {
+        state: Mutex::new(State {
+            output: Output::default(),
+            events: VecDeque::new(),
+            pending: 0,
+            done: false,
+            error: None,
+        }),
+        changed: Condvar::new(),
+        cancel: Notify::new(),
+    });
+    {
+        let mut registry = registry().lock().unwrap();
+        registry.retain(|entry| entry.strong_count() > 0);
+        registry.push(Arc::downgrade(&shared));
+    }
+    let handle = Child {
+        pid,
+        shared: shared.clone(),
+        stdin: stdin.clone(),
+        closed: Mutex::new(false),
+    };
+    tokio::spawn(async move {
+        let mut readers = Vec::new();
+        if let Some(pipe) = stdout {
+            readers.push(tokio::spawn(observed_pump(
+                pipe,
+                shared.clone(),
+                1,
+                config.stdout_mode,
+                config.output_limit,
+                config.pending_limit,
+            )));
+        }
+        if let Some(pipe) = stderr {
+            readers.push(tokio::spawn(observed_pump(
+                pipe,
+                shared.clone(),
+                if config.merge_stderr { 1 } else { 2 },
+                if config.merge_stderr {
+                    config.stdout_mode
+                } else {
+                    config.stderr_mode
+                },
+                config.output_limit,
+                config.pending_limit,
+            )));
+        }
+        let mut writer = if config.stdin_mode == 3 {
+            let shared = shared.clone();
+            Some(tokio::spawn(async move {
+                let result = if let Some(mut input) = automatic_input {
+                    input.write_all(&config.input).await
+                } else {
+                    Ok(())
+                };
+                if let Err(error) = &result {
+                    report_error(&shared, error);
+                }
+                result
+            }))
+        } else {
+            None
+        };
+        let completion = async {
+            let status = child.wait().await?;
+            for reader in &mut readers {
+                reader.await.map_err(io::Error::other)??;
+            }
+            if let Some(writer) = writer.as_mut() {
+                writer.await.map_err(io::Error::other)??;
+            }
+            Ok::<_, io::Error>(status)
+        };
+        let completed = tokio::select! {
+            result = completion => Some(result),
+            _ = shared.cancel.notified() => None,
+            _ = async { if let Some(deadline)=deadline {tokio::time::sleep_until(deadline).await} else {std::future::pending::<()>().await} } => {shared.state.lock().unwrap().output.failure=1;None},
+        };
+        let status = match completed {
+            Some(Ok(status)) => Ok(status),
+            Some(Err(err)) => {
+                let _ = child.start_kill();
+                let _ = child.wait().await;
+                Err(err)
+            }
+            None => {
+                let _ = child.start_kill();
+                child.wait().await
+            }
+        };
+        for reader in readers {
+            reader.abort();
+        }
+        if let Some(writer) = writer {
+            writer.abort();
+        }
+        stdin.lock().await.take();
+        let mut state = shared.state.lock().unwrap();
+        match status {
+            Ok(status) => {
+                state.output.exit_code = status.code().unwrap_or(-1);
+                #[cfg(unix)]
+                {
+                    use std::os::unix::process::ExitStatusExt;
+                    state.output.signal = status.signal().unwrap_or(0);
+                }
+            }
+            Err(err) => state.error = Some((err.kind(), err.to_string())),
+        }
+        state.done = true;
+        shared.changed.notify_all();
+    });
+    Ok(handle)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    fn shell(script: &str) -> Config {
+        let mut command = std::process::Command::new("sh");
+        command.args(["-c", script]);
+        Config {
+            command,
+            stdin_mode: 2,
+            stdout_mode: 3,
+            stderr_mode: 3,
+            input: vec![],
+            timeout_ms: 3000,
+            output_limit: 16 * 1024 * 1024,
+            pending_limit: 1024 * 1024,
+            manage_tree: true,
+            merge_stderr: false,
+        }
+    }
+    #[test]
+    fn canceled_forwarding_does_not_accumulate_blocked_workers() {
+        sync_task(async {
+            let mut releases = Vec::new();
+            for _ in 0..2 {
+                let (release_tx, release_rx) = std::sync::mpsc::channel();
+                let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+                let task = tokio::spawn(forward_blocking(move || {
+                    let _ = started_tx.send(());
+                    release_rx.recv().unwrap();
+                    Ok(())
+                }));
+                started_rx.await.unwrap();
+                task.abort();
+                releases.push(release_tx);
+            }
+            assert_eq!(forwarding_slots().available_permits(), 0);
+            for _ in 0..20 {
+                let task = tokio::spawn(forward_blocking(|| {
+                    panic!("forwarding exceeded worker bound")
+                }));
+                tokio::task::yield_now().await;
+                task.abort();
+            }
+            for release in releases {
+                release.send(()).unwrap();
+            }
+            tokio::time::timeout(Duration::from_secs(1), async {
+                while forwarding_slots().available_permits() != 2 {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .unwrap();
+        });
+    }
+    #[test]
+    fn nonzero_and_bytes() {
+        let child = Child::spawn(shell("printf '\\377'; printf err >&2; exit 7")).unwrap();
+        let output = child.wait().unwrap();
+        assert_eq!(output.exit_code, 7);
+        assert_eq!(output.stdout, [255]);
+        assert_eq!(output.stderr, b"err");
+        assert_eq!(child.wait().unwrap().exit_code, 7);
+    }
+    #[test]
+    fn simultaneous_output_cannot_deadlock() {
+        let output = Child::spawn(shell(
+            "(head -c 200000 /dev/zero >&2) & head -c 200000 /dev/zero; wait",
+        ))
+        .unwrap()
+        .wait()
+        .unwrap();
+        assert_eq!(output.stdout.len(), 200000);
+        assert_eq!(output.stderr.len(), 200000);
+        assert_eq!(output.failure, 0);
+    }
+    #[test]
+    fn capture_limit_retains_bounded_partial_output() {
+        let mut config = shell("head -c 200000 /dev/zero");
+        config.output_limit = 1000;
+        let output = Child::spawn(config).unwrap().wait().unwrap();
+        assert_eq!(output.failure, 2);
+        assert_eq!(output.stdout.len(), 1000);
+    }
+    #[test]
+    fn deadline_includes_descendant_pipe_ownership() {
+        let mut config = shell("sleep 30 & exit 0");
+        config.timeout_ms = 60;
+        let before = Instant::now();
+        let output = Child::spawn(config).unwrap().wait().unwrap();
+        assert_eq!(output.failure, 1);
+        assert!(before.elapsed() < Duration::from_secs(2));
+    }
+    #[test]
+    fn interactive_stdin_and_chunked_output() {
+        let mut config = shell("cat");
+        config.stdin_mode = 4;
+        config.stdout_mode = 4;
+        let child = Child::spawn(config).unwrap();
+        assert!(child.try_wait().unwrap().is_none());
+        child.write(b"hello".to_vec(), 1000).unwrap();
+        child.close_stdin().unwrap();
+        let mut bytes = Vec::new();
+        loop {
+            let event = child.read(2, 1000).unwrap();
+            if event.stream == 0 {
+                break;
+            }
+            assert!(event.bytes.len() <= 2);
+            bytes.extend(event.bytes);
+        }
+        assert_eq!(bytes, b"hello");
+        assert_eq!(child.wait().unwrap().exit_code, 0);
+        child.close().unwrap();
+        child.close().unwrap();
+        assert!(child.pid().is_err());
+    }
+    #[test]
+    fn cwd_does_not_change_parent() {
+        let original = std::env::current_dir().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let mut config = shell("pwd");
+        config.command.current_dir(tmp.path());
+        let child = Child::spawn(config).unwrap();
+        let output = child.wait().unwrap();
+        assert_eq!(
+            String::from_utf8(output.stdout).unwrap().trim(),
+            tmp.path().to_str().unwrap()
+        );
+        assert_eq!(std::env::current_dir().unwrap(), original);
+    }
+    #[test]
+    fn drop_terminates_and_reaps() {
+        let child = Child::spawn(shell("sleep 30")).unwrap();
+        let shared = child.shared.clone();
+        drop(child);
+        let state = shared.state.lock().unwrap();
+        let (state, result) = shared
+            .changed
+            .wait_timeout_while(state, Duration::from_secs(2), |state| !state.done)
+            .unwrap();
+        assert!(!result.timed_out());
+        assert!(state.done);
+    }
+    #[test]
+    fn merged_output_preserves_kernel_pipe_order() {
+        let mut config = shell("printf a; printf b >&2; printf c; printf d >&2");
+        config.merge_stderr = true;
+        let output = Child::spawn(config).unwrap().wait().unwrap();
+        assert_eq!(output.stdout, b"abcd");
+        assert!(output.stderr.is_empty());
+    }
+    #[test]
+    fn automatic_input_is_not_lost_by_wait() {
+        let mut config = shell("cat");
+        config.stdin_mode = 3;
+        config.input = vec![42; 200000];
+        let output = Child::spawn(config).unwrap().wait().unwrap();
+        assert_eq!(output.stdout, vec![42; 200000]);
+    }
+    #[test]
+    fn wait_closes_interactive_stdin() {
+        let mut config = shell("cat");
+        config.stdin_mode = 4;
+        let child = Child::spawn(config).unwrap();
+        assert_eq!(child.wait().unwrap().exit_code, 0);
+    }
+    #[test]
+    fn signal_status_and_kill() {
+        let child = Child::spawn(shell("sleep 30")).unwrap();
+        child.kill().unwrap();
+        let output = child.wait().unwrap();
+        assert_eq!(output.signal, libc::SIGKILL);
+        assert_eq!(output.failure, 0);
+    }
+    #[test]
+    fn pending_output_limit_is_bounded() {
+        let mut config = shell("head -c 200000 /dev/zero");
+        config.stdout_mode = 4;
+        config.pending_limit = 1000;
+        let child = Child::spawn(config).unwrap();
+        let output = child.wait().unwrap();
+        assert_eq!(output.failure, 2);
+        assert_eq!(child.read(2000, 1000).unwrap().bytes.len(), 1000);
+    }
+    #[test]
+    fn native_arguments_survive_without_utf8_conversion() {
+        use std::os::unix::ffi::OsStringExt;
+        let mut config = shell("printf '%s' \"$1\"");
+        config
+            .command
+            .arg("script")
+            .arg(std::ffi::OsString::from_vec(vec![255, 42]));
+        let output = Child::spawn(config).unwrap().wait().unwrap();
+        assert_eq!(output.stdout, [255, 42]);
+    }
+    #[test]
+    fn missing_program_is_spawn_error() {
+        let mut config = shell("");
+        config.command = std::process::Command::new("/does/not/exist/basic-cli");
+        assert_eq!(
+            Child::spawn(config).err().unwrap().kind(),
+            io::ErrorKind::NotFound
+        );
+    }
+}

--- a/src/process_service.rs
+++ b/src/process_service.rs
@@ -656,8 +656,8 @@ mod tests {
         let child = Child::spawn(config).unwrap();
         let output = child.wait().unwrap();
         assert_eq!(
-            String::from_utf8(output.stdout).unwrap().trim(),
-            tmp.path().to_str().unwrap()
+            std::path::Path::new(String::from_utf8(output.stdout).unwrap().trim()),
+            std::fs::canonicalize(tmp.path()).unwrap()
         );
         assert_eq!(std::env::current_dir().unwrap(), original);
     }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,0 +1,111 @@
+//! Native resources whose lifetime follows the Roc box, including Roc-side frees.
+//!
+//! Glue payload callbacks alone cannot implement this: compiled Roc may perform
+//! the final decref without calling a hosted function. Register the allocation
+//! base and finalize from both allocator entrypoints instead.
+use crate::roc_platform_abi::*;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ffi::c_void;
+
+struct Finalizer {
+    payload: *mut u64,
+    drop: unsafe fn(*mut u64),
+}
+
+thread_local! {
+    // Roc and its existing SQLite resources are confined to the host thread.
+    // Background services own Rust data and receive cancellation on destruction.
+    static RESOURCES: RefCell<HashMap<usize, Finalizer>> = RefCell::new(HashMap::new());
+}
+
+pub fn box_resource<T>(value: T, host: &RocHost) -> *mut u64 {
+    let payload = unsafe { allocate_box(size_of::<u64>(), align_of::<u64>(), false, host) } as *mut u64;
+    unsafe { payload.write(Box::into_raw(Box::new(value)) as u64) };
+    let base = unsafe { payload.cast::<u8>().sub(size_of::<usize>().max(align_of::<u64>())) };
+    RESOURCES.with(|resources| {
+        let old = resources.borrow_mut().insert(base as usize, Finalizer { payload, drop: drop_resource::<T> });
+        assert!(old.is_none(), "resource allocation registered twice");
+    });
+    payload
+}
+
+unsafe fn drop_resource<T>(payload: *mut u64) {
+    let raw = unsafe { payload.read() } as *mut T;
+    if !raw.is_null() {
+        unsafe { payload.write(0); drop(Box::from_raw(raw)); }
+    }
+}
+
+/// The caller must pass a live handle allocated for T and serialize access.
+pub unsafe fn resource_ref<'a, T>(handle: *mut u64) -> &'a mut T {
+    unsafe { &mut *(*handle as *mut T) }
+}
+
+pub fn release(handle: *mut u64, host: &RocHost) {
+    unsafe { decref_box_with(handle.cast(), align_of::<u64>(), false, None, host) };
+}
+
+pub extern "C" fn dealloc(host: *mut RocHost, ptr: *mut c_void, alignment: usize) {
+    // Remove before dropping: a native destructor can release other resources.
+    let finalizer = RESOURCES.with(|resources| resources.borrow_mut().remove(&(ptr as usize)));
+    if let Some(finalizer) = finalizer {
+        unsafe { (finalizer.drop)(finalizer.payload) };
+    }
+    DefaultAllocators::roc_dealloc(host, ptr, alignment);
+}
+
+pub fn make_host() -> RocHost {
+    let mut host = make_roc_host(std::ptr::null_mut());
+    host.roc_dealloc = dealloc;
+    host
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::rc::Rc;
+    use std::cell::Cell;
+
+    struct CountDrop(Rc<Cell<usize>>);
+    impl Drop for CountDrop {
+        fn drop(&mut self) { self.0.set(self.0.get() + 1); }
+    }
+
+    #[test]
+    fn final_host_release_destroys_exactly_once() {
+        let host = make_host();
+        let count = Rc::new(Cell::new(0));
+        let handle = box_resource(CountDrop(count.clone()), &host);
+        unsafe { incref_box(handle.cast(), 1) };
+        release(handle, &host);
+        assert_eq!(count.get(), 0);
+        release(handle, &host);
+        assert_eq!(count.get(), 1);
+    }
+
+    #[test]
+    fn roc_style_final_free_destroys_payload() {
+        let mut host = make_host();
+        let count = Rc::new(Cell::new(0));
+        let handle = box_resource(CountDrop(count.clone()), &host);
+        // Compiled Roc frees the allocation directly after decrementing to zero.
+        let base = unsafe { handle.cast::<u8>().sub(size_of::<usize>().max(align_of::<u64>())) };
+        dealloc(&mut host, base.cast(), align_of::<u64>());
+        assert_eq!(count.get(), 1);
+    }
+
+    #[test]
+    fn destructor_can_release_another_registered_resource() {
+        struct Nested { handle: *mut u64, host: RocHost }
+        impl Drop for Nested {
+            fn drop(&mut self) { release(self.handle, &self.host); }
+        }
+        let host = make_host();
+        let count = Rc::new(Cell::new(0));
+        let inner = box_resource(CountDrop(count.clone()), &host);
+        let outer = box_resource(Nested { handle: inner, host: make_host() }, &host);
+        release(outer, &host);
+        assert_eq!(count.get(), 1);
+    }
+}

--- a/src/roc_platform_abi.rs
+++ b/src/roc_platform_abi.rs
@@ -1098,36 +1098,56 @@ unsafe impl<T> RocRelease<*mut T> for RocBoxSpineRelease<T> {
     }
 }
 
-/// Element type for __AnonStruct_32ddec9aa3de7110
+/// Element type for __AnonStruct_b57902ff7f66e961
 #[cfg(target_pointer_width = "32")]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStruct32ddec9aa3de7110 {
+pub struct AnonStructB57902ff7f66e961 {
+    pub output_limit: u64,
+    pub pending_limit: u64,
+    pub timeout_ms: u64,
     pub args: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub cwd: RocList<UnixBytesOrUtf8OrWindowsU16s>,
     pub envs: RocList<UnixBytesOrUtf8OrWindowsU16s>,
     pub program: UnixBytesOrUtf8OrWindowsU16s,
+    pub stdin_bytes: RocListWith<u8, false>,
     pub clear_envs: bool,
+    pub manage_tree: bool,
+    pub merge_stderr: bool,
+    pub stderr_mode: u8,
+    pub stdin_mode: u8,
+    pub stdout_mode: u8,
 }
 
-/// Element type for __AnonStruct_32ddec9aa3de7110
+/// Element type for __AnonStruct_b57902ff7f66e961
 #[cfg(not(target_pointer_width = "32"))]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStruct32ddec9aa3de7110 {
+pub struct AnonStructB57902ff7f66e961 {
+    pub output_limit: u64,
+    pub pending_limit: u64,
+    pub timeout_ms: u64,
     pub args: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub cwd: RocList<UnixBytesOrUtf8OrWindowsU16s>,
     pub envs: RocList<UnixBytesOrUtf8OrWindowsU16s>,
     pub program: UnixBytesOrUtf8OrWindowsU16s,
+    pub stdin_bytes: RocListWith<u8, false>,
     pub clear_envs: bool,
+    pub manage_tree: bool,
+    pub merge_stderr: bool,
+    pub stderr_mode: u8,
+    pub stdin_mode: u8,
+    pub stdout_mode: u8,
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<AnonStruct32ddec9aa3de7110>() == 88, "AnonStruct32ddec9aa3de7110 size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStructB57902ff7f66e961>() == 160, "AnonStructB57902ff7f66e961 size mismatch");
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::align_of::<AnonStruct32ddec9aa3de7110>() == 8, "AnonStruct32ddec9aa3de7110 alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStructB57902ff7f66e961>() == 8, "AnonStructB57902ff7f66e961 alignment mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::size_of::<AnonStruct32ddec9aa3de7110>() == 44, "AnonStruct32ddec9aa3de7110 size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStructB57902ff7f66e961>() == 96, "AnonStructB57902ff7f66e961 size mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::align_of::<AnonStruct32ddec9aa3de7110>() == 4, "AnonStruct32ddec9aa3de7110 alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStructB57902ff7f66e961>() == 8, "AnonStructB57902ff7f66e961 alignment mismatch");
 
 /// Element type for __AnonStruct_3f89ee1e14924626
 #[cfg(target_pointer_width = "32")]
@@ -1383,6 +1403,124 @@ const _: () = assert!(core::mem::align_of::<AnonStruct69eee2ff6c448fed>() == 8, 
 const _: () = assert!(core::mem::size_of::<AnonStruct69eee2ff6c448fed>() == 32, "AnonStruct69eee2ff6c448fed size mismatch");
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::align_of::<AnonStruct69eee2ff6c448fed>() == 4, "AnonStruct69eee2ff6c448fed alignment mismatch");
+
+/// Element type for __AnonStruct_75cf0dfdbccd3932
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStruct75cf0dfdbccd3932 {
+    pub destination: UnixBytesOrUtf8OrWindowsU16s,
+    pub error: IOErr,
+    pub operation: RocStr,
+    pub source: UnixBytesOrUtf8OrWindowsU16s,
+}
+
+/// Element type for __AnonStruct_75cf0dfdbccd3932
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStruct75cf0dfdbccd3932 {
+    pub destination: UnixBytesOrUtf8OrWindowsU16s,
+    pub error: IOErr,
+    pub operation: RocStr,
+    pub source: UnixBytesOrUtf8OrWindowsU16s,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<AnonStruct75cf0dfdbccd3932>() == 120, "AnonStruct75cf0dfdbccd3932 size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<AnonStruct75cf0dfdbccd3932>() == 8, "AnonStruct75cf0dfdbccd3932 alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<AnonStruct75cf0dfdbccd3932>() == 60, "AnonStruct75cf0dfdbccd3932 size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<AnonStruct75cf0dfdbccd3932>() == 4, "AnonStruct75cf0dfdbccd3932 alignment mismatch");
+
+/// Element type for __AnonStruct_dee0b5b198beef56
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStructDee0b5b198beef56 {
+    pub destination: MergeOrRequireNew,
+    pub symlinks: FollowOrPreserve,
+}
+
+/// Element type for __AnonStruct_dee0b5b198beef56
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStructDee0b5b198beef56 {
+    pub destination: MergeOrRequireNew,
+    pub symlinks: FollowOrPreserve,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<AnonStructDee0b5b198beef56>() == 2, "AnonStructDee0b5b198beef56 size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<AnonStructDee0b5b198beef56>() == 1, "AnonStructDee0b5b198beef56 alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<AnonStructDee0b5b198beef56>() == 2, "AnonStructDee0b5b198beef56 size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<AnonStructDee0b5b198beef56>() == 1, "AnonStructDee0b5b198beef56 alignment mismatch");
+
+/// Element type for __AnonStruct_da30c5358d228170
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStructDa30c5358d228170 {
+    pub stderr_bytes: RocListWith<u8, false>,
+    pub stdout_bytes: RocListWith<u8, false>,
+    pub exit_code: i32,
+    pub signal: i32,
+    pub failure: u8,
+}
+
+/// Element type for __AnonStruct_da30c5358d228170
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStructDa30c5358d228170 {
+    pub stderr_bytes: RocListWith<u8, false>,
+    pub stdout_bytes: RocListWith<u8, false>,
+    pub exit_code: i32,
+    pub signal: i32,
+    pub failure: u8,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<AnonStructDa30c5358d228170>() == 64, "AnonStructDa30c5358d228170 size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<AnonStructDa30c5358d228170>() == 8, "AnonStructDa30c5358d228170 alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<AnonStructDa30c5358d228170>() == 36, "AnonStructDa30c5358d228170 size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<AnonStructDa30c5358d228170>() == 4, "AnonStructDa30c5358d228170 alignment mismatch");
+
+/// Element type for __AnonStruct_90571bef66942268
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStruct90571bef66942268 {
+    pub bytes: RocListWith<u8, false>,
+    pub stream: u8,
+}
+
+/// Element type for __AnonStruct_90571bef66942268
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStruct90571bef66942268 {
+    pub bytes: RocListWith<u8, false>,
+    pub stream: u8,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<AnonStruct90571bef66942268>() == 32, "AnonStruct90571bef66942268 size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<AnonStruct90571bef66942268>() == 8, "AnonStruct90571bef66942268 alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<AnonStruct90571bef66942268>() == 16, "AnonStruct90571bef66942268 size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<AnonStruct90571bef66942268>() == 4, "AnonStruct90571bef66942268 alignment mismatch");
 
 /// Tag discriminant for Try.
 #[repr(u8)]
@@ -6414,6 +6552,1147 @@ const _: () = assert!(core::mem::align_of::<HostEnvSetCwdResult>() == 4, "HostEn
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::offset_of!(HostEnvSetCwdResult, tag) == 16, "HostEnvSetCwdResult tag offset mismatch");
 
+/// Tag discriminant for Try.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostPathCopyResultTag {
+    Err = 0,
+    Ok = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union HostPathCopyResultPayload {
+    pub err: core::mem::ManuallyDrop<AnonStruct75cf0dfdbccd3932>,
+    pub ok: [u8; 0],
+}
+
+#[cfg(target_pointer_width = "32")]
+#[repr(align(4))]
+#[derive(Clone, Copy)]
+pub struct HostPathCopyResultPayloadAlignment;
+
+/// Tag union: Try
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostPathCopyResult {
+    pub _payload_alignment: [HostPathCopyResultPayloadAlignment; 0],
+    pub payload: [u8; 60],
+    pub tag: HostPathCopyResultTag,
+}
+
+/// Tag union: Try
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostPathCopyResult {
+    pub payload: HostPathCopyResultPayload,
+    pub tag: HostPathCopyResultTag,
+}
+
+impl HostPathCopyResult {
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostPathCopyResultTag::Err` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &AnonStruct75cf0dfdbccd3932 {
+        unsafe { &*(self.payload.as_ptr() as *const AnonStruct75cf0dfdbccd3932) }
+    }
+
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostPathCopyResultTag::Err` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &AnonStruct75cf0dfdbccd3932 {
+        unsafe { &*(&self.payload.err as *const core::mem::ManuallyDrop<AnonStruct75cf0dfdbccd3932> as *const AnonStruct75cf0dfdbccd3932) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostPathCopyResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> AnonStruct75cf0dfdbccd3932 {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const AnonStruct75cf0dfdbccd3932) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostPathCopyResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> AnonStruct75cf0dfdbccd3932 {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.err) }
+    }
+
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<HostPathCopyResult>() == 128, "HostPathCopyResult size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<HostPathCopyResult>() == 8, "HostPathCopyResult alignment mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::offset_of!(HostPathCopyResult, tag) == 120, "HostPathCopyResult tag offset mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<HostPathCopyResult>() == 64, "HostPathCopyResult size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<HostPathCopyResult>() == 4, "HostPathCopyResult alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::offset_of!(HostPathCopyResult, tag) == 60, "HostPathCopyResult tag offset mismatch");
+
+/// Tag union: MergeOrRequireNew
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeOrRequireNew {
+    Merge = 0,
+    RequireNew = 1,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<MergeOrRequireNew>() == 1, "MergeOrRequireNew size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<MergeOrRequireNew>() == 1, "MergeOrRequireNew alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<MergeOrRequireNew>() == 1, "MergeOrRequireNew size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<MergeOrRequireNew>() == 1, "MergeOrRequireNew alignment mismatch");
+
+/// Tag union: FollowOrPreserve
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FollowOrPreserve {
+    Follow = 0,
+    Preserve = 1,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<FollowOrPreserve>() == 1, "FollowOrPreserve size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<FollowOrPreserve>() == 1, "FollowOrPreserve alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<FollowOrPreserve>() == 1, "FollowOrPreserve size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<FollowOrPreserve>() == 1, "FollowOrPreserve alignment mismatch");
+
+/// Tag discriminant for Try.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostPathAbsoluteResultTag {
+    Err = 0,
+    Ok = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union HostPathAbsoluteResultPayload {
+    pub err: core::mem::ManuallyDrop<IOErr>,
+    pub ok: core::mem::ManuallyDrop<UnixBytesOrUtf8OrWindowsU16s>,
+}
+
+#[cfg(target_pointer_width = "32")]
+#[repr(align(4))]
+#[derive(Clone, Copy)]
+pub struct HostPathAbsoluteResultPayloadAlignment;
+
+/// Tag union: Try
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostPathAbsoluteResult {
+    pub _payload_alignment: [HostPathAbsoluteResultPayloadAlignment; 0],
+    pub payload: [u8; 16],
+    pub tag: HostPathAbsoluteResultTag,
+}
+
+/// Tag union: Try
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostPathAbsoluteResult {
+    pub payload: HostPathAbsoluteResultPayload,
+    pub tag: HostPathAbsoluteResultTag,
+}
+
+impl HostPathAbsoluteResult {
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostPathAbsoluteResultTag::Err` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &IOErr {
+        unsafe { &*(self.payload.as_ptr() as *const IOErr) }
+    }
+
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostPathAbsoluteResultTag::Err` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &IOErr {
+        unsafe { &*(&self.payload.err as *const core::mem::ManuallyDrop<IOErr> as *const IOErr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostPathAbsoluteResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> IOErr {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const IOErr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostPathAbsoluteResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> IOErr {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.err) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostPathAbsoluteResultTag::Ok` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &UnixBytesOrUtf8OrWindowsU16s {
+        unsafe { &*(self.payload.as_ptr() as *const UnixBytesOrUtf8OrWindowsU16s) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostPathAbsoluteResultTag::Ok` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &UnixBytesOrUtf8OrWindowsU16s {
+        unsafe { &*(&self.payload.ok as *const core::mem::ManuallyDrop<UnixBytesOrUtf8OrWindowsU16s> as *const UnixBytesOrUtf8OrWindowsU16s) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostPathAbsoluteResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> UnixBytesOrUtf8OrWindowsU16s {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const UnixBytesOrUtf8OrWindowsU16s) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostPathAbsoluteResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> UnixBytesOrUtf8OrWindowsU16s {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.ok) }
+    }
+
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<HostPathAbsoluteResult>() == 40, "HostPathAbsoluteResult size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<HostPathAbsoluteResult>() == 8, "HostPathAbsoluteResult alignment mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::offset_of!(HostPathAbsoluteResult, tag) == 32, "HostPathAbsoluteResult tag offset mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<HostPathAbsoluteResult>() == 20, "HostPathAbsoluteResult size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<HostPathAbsoluteResult>() == 4, "HostPathAbsoluteResult alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::offset_of!(HostPathAbsoluteResult, tag) == 16, "HostPathAbsoluteResult tag offset mismatch");
+
+/// Tag discriminant for Try.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostCmdSpawnResultTag {
+    Err = 0,
+    Ok = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union HostCmdSpawnResultPayload {
+    pub err: core::mem::ManuallyDrop<IOErr>,
+    pub ok: core::mem::ManuallyDrop<*mut u64>,
+}
+
+#[cfg(target_pointer_width = "32")]
+#[repr(align(4))]
+#[derive(Clone, Copy)]
+pub struct HostCmdSpawnResultPayloadAlignment;
+
+/// Tag union: Try
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostCmdSpawnResult {
+    pub _payload_alignment: [HostCmdSpawnResultPayloadAlignment; 0],
+    pub payload: [u8; 16],
+    pub tag: HostCmdSpawnResultTag,
+}
+
+/// Tag union: Try
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostCmdSpawnResult {
+    pub payload: HostCmdSpawnResultPayload,
+    pub tag: HostCmdSpawnResultTag,
+}
+
+impl HostCmdSpawnResult {
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdSpawnResultTag::Err` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &IOErr {
+        unsafe { &*(self.payload.as_ptr() as *const IOErr) }
+    }
+
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdSpawnResultTag::Err` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &IOErr {
+        unsafe { &*(&self.payload.err as *const core::mem::ManuallyDrop<IOErr> as *const IOErr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdSpawnResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> IOErr {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const IOErr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdSpawnResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> IOErr {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.err) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdSpawnResultTag::Ok` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &*mut u64 {
+        unsafe { &*(self.payload.as_ptr() as *const *mut u64) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdSpawnResultTag::Ok` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &*mut u64 {
+        unsafe { &*(&self.payload.ok as *const core::mem::ManuallyDrop<*mut u64> as *const *mut u64) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdSpawnResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> *mut u64 {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const *mut u64) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdSpawnResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> *mut u64 {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.ok) }
+    }
+
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<HostCmdSpawnResult>() == 40, "HostCmdSpawnResult size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<HostCmdSpawnResult>() == 8, "HostCmdSpawnResult alignment mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::offset_of!(HostCmdSpawnResult, tag) == 32, "HostCmdSpawnResult tag offset mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<HostCmdSpawnResult>() == 20, "HostCmdSpawnResult size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<HostCmdSpawnResult>() == 4, "HostCmdSpawnResult alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::offset_of!(HostCmdSpawnResult, tag) == 16, "HostCmdSpawnResult tag offset mismatch");
+
+/// Tag discriminant for Try.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostCmdRunResultTag {
+    Err = 0,
+    Ok = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union HostCmdRunResultPayload {
+    pub err: core::mem::ManuallyDrop<IOErr>,
+    pub ok: core::mem::ManuallyDrop<AnonStructDa30c5358d228170>,
+}
+
+#[cfg(target_pointer_width = "32")]
+#[repr(align(4))]
+#[derive(Clone, Copy)]
+pub struct HostCmdRunResultPayloadAlignment;
+
+/// Tag union: Try
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostCmdRunResult {
+    pub _payload_alignment: [HostCmdRunResultPayloadAlignment; 0],
+    pub payload: [u8; 36],
+    pub tag: HostCmdRunResultTag,
+}
+
+/// Tag union: Try
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostCmdRunResult {
+    pub payload: HostCmdRunResultPayload,
+    pub tag: HostCmdRunResultTag,
+}
+
+impl HostCmdRunResult {
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdRunResultTag::Err` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &IOErr {
+        unsafe { &*(self.payload.as_ptr() as *const IOErr) }
+    }
+
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdRunResultTag::Err` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &IOErr {
+        unsafe { &*(&self.payload.err as *const core::mem::ManuallyDrop<IOErr> as *const IOErr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdRunResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> IOErr {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const IOErr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdRunResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> IOErr {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.err) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdRunResultTag::Ok` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &AnonStructDa30c5358d228170 {
+        unsafe { &*(self.payload.as_ptr() as *const AnonStructDa30c5358d228170) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdRunResultTag::Ok` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &AnonStructDa30c5358d228170 {
+        unsafe { &*(&self.payload.ok as *const core::mem::ManuallyDrop<AnonStructDa30c5358d228170> as *const AnonStructDa30c5358d228170) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdRunResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> AnonStructDa30c5358d228170 {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const AnonStructDa30c5358d228170) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostCmdRunResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> AnonStructDa30c5358d228170 {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.ok) }
+    }
+
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<HostCmdRunResult>() == 72, "HostCmdRunResult size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<HostCmdRunResult>() == 8, "HostCmdRunResult alignment mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::offset_of!(HostCmdRunResult, tag) == 64, "HostCmdRunResult tag offset mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<HostCmdRunResult>() == 40, "HostCmdRunResult size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<HostCmdRunResult>() == 4, "HostCmdRunResult alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::offset_of!(HostCmdRunResult, tag) == 36, "HostCmdRunResult tag offset mismatch");
+
+/// Tag discriminant for Try.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostChildPidResultTag {
+    Err = 0,
+    Ok = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union HostChildPidResultPayload {
+    pub err: core::mem::ManuallyDrop<IOErr>,
+    pub ok: core::mem::ManuallyDrop<u32>,
+}
+
+#[cfg(target_pointer_width = "32")]
+#[repr(align(4))]
+#[derive(Clone, Copy)]
+pub struct HostChildPidResultPayloadAlignment;
+
+/// Tag union: Try
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostChildPidResult {
+    pub _payload_alignment: [HostChildPidResultPayloadAlignment; 0],
+    pub payload: [u8; 16],
+    pub tag: HostChildPidResultTag,
+}
+
+/// Tag union: Try
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostChildPidResult {
+    pub payload: HostChildPidResultPayload,
+    pub tag: HostChildPidResultTag,
+}
+
+impl HostChildPidResult {
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildPidResultTag::Err` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &IOErr {
+        unsafe { &*(self.payload.as_ptr() as *const IOErr) }
+    }
+
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildPidResultTag::Err` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &IOErr {
+        unsafe { &*(&self.payload.err as *const core::mem::ManuallyDrop<IOErr> as *const IOErr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildPidResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> IOErr {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const IOErr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildPidResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> IOErr {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.err) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildPidResultTag::Ok` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &u32 {
+        unsafe { &*(self.payload.as_ptr() as *const u32) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildPidResultTag::Ok` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &u32 {
+        unsafe { &*(&self.payload.ok as *const core::mem::ManuallyDrop<u32> as *const u32) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildPidResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> u32 {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const u32) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildPidResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> u32 {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.ok) }
+    }
+
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<HostChildPidResult>() == 40, "HostChildPidResult size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<HostChildPidResult>() == 8, "HostChildPidResult alignment mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::offset_of!(HostChildPidResult, tag) == 32, "HostChildPidResult tag offset mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<HostChildPidResult>() == 20, "HostChildPidResult size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<HostChildPidResult>() == 4, "HostChildPidResult alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::offset_of!(HostChildPidResult, tag) == 16, "HostChildPidResult tag offset mismatch");
+
+/// Tag discriminant for Try.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostChildTryWaitResultTag {
+    Err = 0,
+    Ok = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union HostChildTryWaitResultPayload {
+    pub err: core::mem::ManuallyDrop<IOErr>,
+    pub ok: core::mem::ManuallyDrop<RocList<AnonStructDa30c5358d228170>>,
+}
+
+#[cfg(target_pointer_width = "32")]
+#[repr(align(4))]
+#[derive(Clone, Copy)]
+pub struct HostChildTryWaitResultPayloadAlignment;
+
+/// Tag union: Try
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostChildTryWaitResult {
+    pub _payload_alignment: [HostChildTryWaitResultPayloadAlignment; 0],
+    pub payload: [u8; 16],
+    pub tag: HostChildTryWaitResultTag,
+}
+
+/// Tag union: Try
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostChildTryWaitResult {
+    pub payload: HostChildTryWaitResultPayload,
+    pub tag: HostChildTryWaitResultTag,
+}
+
+impl HostChildTryWaitResult {
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildTryWaitResultTag::Err` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &IOErr {
+        unsafe { &*(self.payload.as_ptr() as *const IOErr) }
+    }
+
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildTryWaitResultTag::Err` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &IOErr {
+        unsafe { &*(&self.payload.err as *const core::mem::ManuallyDrop<IOErr> as *const IOErr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildTryWaitResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> IOErr {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const IOErr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildTryWaitResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> IOErr {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.err) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildTryWaitResultTag::Ok` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &RocList<AnonStructDa30c5358d228170> {
+        unsafe { &*(self.payload.as_ptr() as *const RocList<AnonStructDa30c5358d228170>) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildTryWaitResultTag::Ok` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &RocList<AnonStructDa30c5358d228170> {
+        unsafe { &*(&self.payload.ok as *const core::mem::ManuallyDrop<RocList<AnonStructDa30c5358d228170>> as *const RocList<AnonStructDa30c5358d228170>) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildTryWaitResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> RocList<AnonStructDa30c5358d228170> {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const RocList<AnonStructDa30c5358d228170>) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildTryWaitResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> RocList<AnonStructDa30c5358d228170> {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.ok) }
+    }
+
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<HostChildTryWaitResult>() == 40, "HostChildTryWaitResult size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<HostChildTryWaitResult>() == 8, "HostChildTryWaitResult alignment mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::offset_of!(HostChildTryWaitResult, tag) == 32, "HostChildTryWaitResult tag offset mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<HostChildTryWaitResult>() == 20, "HostChildTryWaitResult size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<HostChildTryWaitResult>() == 4, "HostChildTryWaitResult alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::offset_of!(HostChildTryWaitResult, tag) == 16, "HostChildTryWaitResult tag offset mismatch");
+
+/// Tag discriminant for Try.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostChildReadResultTag {
+    Err = 0,
+    Ok = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union HostChildReadResultPayload {
+    pub err: core::mem::ManuallyDrop<IOErr>,
+    pub ok: core::mem::ManuallyDrop<AnonStruct90571bef66942268>,
+}
+
+#[cfg(target_pointer_width = "32")]
+#[repr(align(4))]
+#[derive(Clone, Copy)]
+pub struct HostChildReadResultPayloadAlignment;
+
+/// Tag union: Try
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostChildReadResult {
+    pub _payload_alignment: [HostChildReadResultPayloadAlignment; 0],
+    pub payload: [u8; 16],
+    pub tag: HostChildReadResultTag,
+}
+
+/// Tag union: Try
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostChildReadResult {
+    pub payload: HostChildReadResultPayload,
+    pub tag: HostChildReadResultTag,
+}
+
+impl HostChildReadResult {
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildReadResultTag::Err` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &IOErr {
+        unsafe { &*(self.payload.as_ptr() as *const IOErr) }
+    }
+
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildReadResultTag::Err` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &IOErr {
+        unsafe { &*(&self.payload.err as *const core::mem::ManuallyDrop<IOErr> as *const IOErr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildReadResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> IOErr {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const IOErr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildReadResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> IOErr {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.err) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildReadResultTag::Ok` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &AnonStruct90571bef66942268 {
+        unsafe { &*(self.payload.as_ptr() as *const AnonStruct90571bef66942268) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildReadResultTag::Ok` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &AnonStruct90571bef66942268 {
+        unsafe { &*(&self.payload.ok as *const core::mem::ManuallyDrop<AnonStruct90571bef66942268> as *const AnonStruct90571bef66942268) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildReadResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> AnonStruct90571bef66942268 {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const AnonStruct90571bef66942268) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostChildReadResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> AnonStruct90571bef66942268 {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.ok) }
+    }
+
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<HostChildReadResult>() == 40, "HostChildReadResult size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<HostChildReadResult>() == 8, "HostChildReadResult alignment mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::offset_of!(HostChildReadResult, tag) == 32, "HostChildReadResult tag offset mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<HostChildReadResult>() == 20, "HostChildReadResult size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<HostChildReadResult>() == 4, "HostChildReadResult alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::offset_of!(HostChildReadResult, tag) == 16, "HostChildReadResult tag offset mismatch");
+
+/// Tag discriminant for Try.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostTcpListenResultTag {
+    Err = 0,
+    Ok = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union HostTcpListenResultPayload {
+    pub err: core::mem::ManuallyDrop<RocStr>,
+    pub ok: core::mem::ManuallyDrop<*mut u64>,
+}
+
+#[cfg(target_pointer_width = "32")]
+#[repr(align(4))]
+#[derive(Clone, Copy)]
+pub struct HostTcpListenResultPayloadAlignment;
+
+/// Tag union: Try
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostTcpListenResult {
+    pub _payload_alignment: [HostTcpListenResultPayloadAlignment; 0],
+    pub payload: [u8; 12],
+    pub tag: HostTcpListenResultTag,
+}
+
+/// Tag union: Try
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostTcpListenResult {
+    pub payload: HostTcpListenResultPayload,
+    pub tag: HostTcpListenResultTag,
+}
+
+impl HostTcpListenResult {
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpListenResultTag::Err` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &RocStr {
+        unsafe { &*(self.payload.as_ptr() as *const RocStr) }
+    }
+
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpListenResultTag::Err` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &RocStr {
+        unsafe { &*(&self.payload.err as *const core::mem::ManuallyDrop<RocStr> as *const RocStr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpListenResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> RocStr {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const RocStr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpListenResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> RocStr {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.err) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpListenResultTag::Ok` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &*mut u64 {
+        unsafe { &*(self.payload.as_ptr() as *const *mut u64) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpListenResultTag::Ok` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &*mut u64 {
+        unsafe { &*(&self.payload.ok as *const core::mem::ManuallyDrop<*mut u64> as *const *mut u64) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpListenResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> *mut u64 {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const *mut u64) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpListenResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> *mut u64 {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.ok) }
+    }
+
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<HostTcpListenResult>() == 32, "HostTcpListenResult size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<HostTcpListenResult>() == 8, "HostTcpListenResult alignment mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::offset_of!(HostTcpListenResult, tag) == 24, "HostTcpListenResult tag offset mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<HostTcpListenResult>() == 16, "HostTcpListenResult size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<HostTcpListenResult>() == 4, "HostTcpListenResult alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::offset_of!(HostTcpListenResult, tag) == 12, "HostTcpListenResult tag offset mismatch");
+
+/// Tag discriminant for Try.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostTcpLocalPortResultTag {
+    Err = 0,
+    Ok = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union HostTcpLocalPortResultPayload {
+    pub err: core::mem::ManuallyDrop<RocStr>,
+    pub ok: core::mem::ManuallyDrop<u16>,
+}
+
+#[cfg(target_pointer_width = "32")]
+#[repr(align(4))]
+#[derive(Clone, Copy)]
+pub struct HostTcpLocalPortResultPayloadAlignment;
+
+/// Tag union: Try
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostTcpLocalPortResult {
+    pub _payload_alignment: [HostTcpLocalPortResultPayloadAlignment; 0],
+    pub payload: [u8; 12],
+    pub tag: HostTcpLocalPortResultTag,
+}
+
+/// Tag union: Try
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostTcpLocalPortResult {
+    pub payload: HostTcpLocalPortResultPayload,
+    pub tag: HostTcpLocalPortResultTag,
+}
+
+impl HostTcpLocalPortResult {
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpLocalPortResultTag::Err` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &RocStr {
+        unsafe { &*(self.payload.as_ptr() as *const RocStr) }
+    }
+
+    /// Borrow the `Err` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpLocalPortResultTag::Err` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_err_unchecked(&self) -> &RocStr {
+        unsafe { &*(&self.payload.err as *const core::mem::ManuallyDrop<RocStr> as *const RocStr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpLocalPortResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> RocStr {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const RocStr) }
+    }
+
+    /// Move the `Err` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpLocalPortResultTag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_err_unchecked(&mut self) -> RocStr {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.err) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpLocalPortResultTag::Ok` and the payload must still be initialized.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &u16 {
+        unsafe { &*(self.payload.as_ptr() as *const u16) }
+    }
+
+    /// Borrow the `Ok` payload without creating another owner.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpLocalPortResultTag::Ok` and the payload must still be initialized.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn borrow_payload_ok_unchecked(&self) -> &u16 {
+        unsafe { &*(&self.payload.ok as *const core::mem::ManuallyDrop<u16> as *const u16) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpLocalPortResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> u16 {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const u16) }
+    }
+
+    /// Move the `Ok` payload out of one owned tag-union shell.
+    ///
+    /// # Safety
+    /// `self.tag` must be `HostTcpLocalPortResultTag::Ok`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    #[cfg(not(target_pointer_width = "32"))]
+    pub unsafe fn take_payload_ok_unchecked(&mut self) -> u16 {
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.ok) }
+    }
+
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<HostTcpLocalPortResult>() == 32, "HostTcpLocalPortResult size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<HostTcpLocalPortResult>() == 8, "HostTcpLocalPortResult alignment mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::offset_of!(HostTcpLocalPortResult, tag) == 24, "HostTcpLocalPortResult tag offset mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<HostTcpLocalPortResult>() == 16, "HostTcpLocalPortResult size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<HostTcpLocalPortResult>() == 4, "HostTcpLocalPortResult alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::offset_of!(HostTcpLocalPortResult, tag) == 12, "HostTcpLocalPortResult tag offset mismatch");
+
 /// Tag discriminant for OsStr.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6582,14 +7861,14 @@ const _: () = assert!(core::mem::offset_of!(OsStr, tag) == 12, "OsStr tag offset
 /// Tag discriminant for Try.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TryType204Tag {
+pub enum TryType259Tag {
     Err = 0,
     Ok = 1,
 }
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union TryType204Payload {
+pub union TryType259Payload {
     pub err: core::mem::ManuallyDrop<i32>,
     pub ok: [u8; 0],
 }
@@ -6597,32 +7876,32 @@ pub union TryType204Payload {
 #[cfg(target_pointer_width = "32")]
 #[repr(align(4))]
 #[derive(Clone, Copy)]
-pub struct TryType204PayloadAlignment;
+pub struct TryType259PayloadAlignment;
 
 /// Tag union: Try
 #[cfg(target_pointer_width = "32")]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct TryType204 {
-    pub _payload_alignment: [TryType204PayloadAlignment; 0],
+pub struct TryType259 {
+    pub _payload_alignment: [TryType259PayloadAlignment; 0],
     pub payload: [u8; 4],
-    pub tag: TryType204Tag,
+    pub tag: TryType259Tag,
 }
 
 /// Tag union: Try
 #[cfg(not(target_pointer_width = "32"))]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct TryType204 {
-    pub payload: TryType204Payload,
-    pub tag: TryType204Tag,
+pub struct TryType259 {
+    pub payload: TryType259Payload,
+    pub tag: TryType259Tag,
 }
 
-impl TryType204 {
+impl TryType259 {
     /// Borrow the `Err` payload without creating another owner.
     ///
     /// # Safety
-    /// `self.tag` must be `TryType204Tag::Err` and the payload must still be initialized.
+    /// `self.tag` must be `TryType259Tag::Err` and the payload must still be initialized.
     #[cfg(target_pointer_width = "32")]
     pub unsafe fn borrow_payload_err_unchecked(&self) -> &i32 {
         unsafe { &*(self.payload.as_ptr() as *const i32) }
@@ -6631,7 +7910,7 @@ impl TryType204 {
     /// Borrow the `Err` payload without creating another owner.
     ///
     /// # Safety
-    /// `self.tag` must be `TryType204Tag::Err` and the payload must still be initialized.
+    /// `self.tag` must be `TryType259Tag::Err` and the payload must still be initialized.
     #[cfg(not(target_pointer_width = "32"))]
     pub unsafe fn borrow_payload_err_unchecked(&self) -> &i32 {
         unsafe { &*(&self.payload.err as *const core::mem::ManuallyDrop<i32> as *const i32) }
@@ -6640,7 +7919,7 @@ impl TryType204 {
     /// Move the `Err` payload out of one owned tag-union shell.
     ///
     /// # Safety
-    /// `self.tag` must be `TryType204Tag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    /// `self.tag` must be `TryType259Tag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
     #[cfg(target_pointer_width = "32")]
     pub unsafe fn take_payload_err_unchecked(&mut self) -> i32 {
         unsafe { core::ptr::read(self.payload.as_ptr() as *const i32) }
@@ -6649,7 +7928,7 @@ impl TryType204 {
     /// Move the `Err` payload out of one owned tag-union shell.
     ///
     /// # Safety
-    /// `self.tag` must be `TryType204Tag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
+    /// `self.tag` must be `TryType259Tag::Err`. After this call, `self` is logically uninitialized and must not be read or destroyed.
     #[cfg(not(target_pointer_width = "32"))]
     pub unsafe fn take_payload_err_unchecked(&mut self) -> i32 {
         unsafe { core::mem::ManuallyDrop::take(&mut self.payload.err) }
@@ -6658,17 +7937,17 @@ impl TryType204 {
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<TryType204>() == 8, "TryType204 size mismatch");
+const _: () = assert!(core::mem::size_of::<TryType259>() == 8, "TryType259 size mismatch");
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::align_of::<TryType204>() == 4, "TryType204 alignment mismatch");
+const _: () = assert!(core::mem::align_of::<TryType259>() == 4, "TryType259 alignment mismatch");
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::offset_of!(TryType204, tag) == 4, "TryType204 tag offset mismatch");
+const _: () = assert!(core::mem::offset_of!(TryType259, tag) == 4, "TryType259 tag offset mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::size_of::<TryType204>() == 8, "TryType204 size mismatch");
+const _: () = assert!(core::mem::size_of::<TryType259>() == 8, "TryType259 size mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::align_of::<TryType204>() == 4, "TryType204 alignment mismatch");
+const _: () = assert!(core::mem::align_of::<TryType259>() == 4, "TryType259 alignment mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::offset_of!(TryType204, tag) == 4, "TryType204 tag offset mismatch");
+const _: () = assert!(core::mem::offset_of!(TryType259, tag) == 4, "TryType259 tag offset mismatch");
 
 /// Return type record for Host.env_platform!
 /// Fields ordered by compiler-emitted ABI offsets.
@@ -6700,39 +7979,59 @@ const _: () = assert!(core::mem::size_of::<HostEnvPlatformRetRecord>() == 32, "H
 const _: () = assert!(core::mem::align_of::<HostEnvPlatformRetRecord>() == 4, "HostEnvPlatformRetRecord alignment mismatch");
 
 /// Arguments for Host.cmd_exec_exit_code!
-/// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] } => Try(I32, IOErr)
+/// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, cwd : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), manage_tree : Bool, merge_stderr : Bool, output_limit : U64, pending_limit : U64, program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], stderr_mode : U8, stdin_bytes : List(U8), stdin_mode : U8, stdout_mode : U8, timeout_ms : U64 } => Try(I32, IOErr)
 /// Refcounted fields are owned by the hosted function.
 #[cfg(target_pointer_width = "32")]
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct HostCmdExecExitCodeArgs {
+    pub output_limit: u64,
+    pub pending_limit: u64,
+    pub timeout_ms: u64,
     pub args: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub cwd: RocList<UnixBytesOrUtf8OrWindowsU16s>,
     pub envs: RocList<UnixBytesOrUtf8OrWindowsU16s>,
     pub program: UnixBytesOrUtf8OrWindowsU16s,
+    pub stdin_bytes: RocListWith<u8, false>,
     pub clear_envs: bool,
+    pub manage_tree: bool,
+    pub merge_stderr: bool,
+    pub stderr_mode: u8,
+    pub stdin_mode: u8,
+    pub stdout_mode: u8,
 }
 
 /// Arguments for Host.cmd_exec_exit_code!
-/// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] } => Try(I32, IOErr)
+/// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, cwd : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), manage_tree : Bool, merge_stderr : Bool, output_limit : U64, pending_limit : U64, program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], stderr_mode : U8, stdin_bytes : List(U8), stdin_mode : U8, stdout_mode : U8, timeout_ms : U64 } => Try(I32, IOErr)
 /// Refcounted fields are owned by the hosted function.
 #[cfg(not(target_pointer_width = "32"))]
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct HostCmdExecExitCodeArgs {
+    pub output_limit: u64,
+    pub pending_limit: u64,
+    pub timeout_ms: u64,
     pub args: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub cwd: RocList<UnixBytesOrUtf8OrWindowsU16s>,
     pub envs: RocList<UnixBytesOrUtf8OrWindowsU16s>,
     pub program: UnixBytesOrUtf8OrWindowsU16s,
+    pub stdin_bytes: RocListWith<u8, false>,
     pub clear_envs: bool,
+    pub manage_tree: bool,
+    pub merge_stderr: bool,
+    pub stderr_mode: u8,
+    pub stdin_mode: u8,
+    pub stdout_mode: u8,
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<HostCmdExecExitCodeArgs>() == 88, "HostCmdExecExitCodeArgs size mismatch");
+const _: () = assert!(core::mem::size_of::<HostCmdExecExitCodeArgs>() == 160, "HostCmdExecExitCodeArgs size mismatch");
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(core::mem::align_of::<HostCmdExecExitCodeArgs>() == 8, "HostCmdExecExitCodeArgs alignment mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::size_of::<HostCmdExecExitCodeArgs>() == 44, "HostCmdExecExitCodeArgs size mismatch");
+const _: () = assert!(core::mem::size_of::<HostCmdExecExitCodeArgs>() == 96, "HostCmdExecExitCodeArgs size mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::align_of::<HostCmdExecExitCodeArgs>() == 4, "HostCmdExecExitCodeArgs alignment mismatch");
+const _: () = assert!(core::mem::align_of::<HostCmdExecExitCodeArgs>() == 8, "HostCmdExecExitCodeArgs alignment mismatch");
 
 impl HostCmdExecExitCodeArgs {
     /// Recursively decrement Roc-owned fields.
@@ -6742,8 +8041,10 @@ impl HostCmdExecExitCodeArgs {
     pub unsafe fn decref(self, roc_host: &RocHost) {
         let value = self;
         unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(value.args, roc_host); }
+        unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(value.cwd, roc_host); }
         unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(value.envs, roc_host); }
         unsafe { value.program.decref(roc_host); }
+        unsafe { value.stdin_bytes.decref(roc_host); }
     }
 
     /// Increment Roc-owned fields.
@@ -6754,8 +8055,10 @@ impl HostCmdExecExitCodeArgs {
     pub unsafe fn incref(self, amount: isize) {
         let value = self;
         unsafe { value.args.incref(amount); }
+        unsafe { value.cwd.incref(amount); }
         unsafe { value.envs.incref(amount); }
         unsafe { value.program.incref(amount); }
+        unsafe { value.stdin_bytes.incref(amount); }
     }
 }
 
@@ -6768,39 +8071,59 @@ unsafe impl RocRelease<HostCmdExecExitCodeArgs> for HostCmdExecExitCodeArgsRelea
 }
 
 /// Arguments for Host.cmd_exec_output!
-/// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] } => Try({ stderr_bytes : List(U8), stdout_bytes : List(U8) }, [FailedToGetExitCode(IOErr), NonZeroExitCode({ exit_code : I32, stderr_bytes : List(U8), stdout_bytes : List(U8) })])
+/// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, cwd : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), manage_tree : Bool, merge_stderr : Bool, output_limit : U64, pending_limit : U64, program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], stderr_mode : U8, stdin_bytes : List(U8), stdin_mode : U8, stdout_mode : U8, timeout_ms : U64 } => Try({ stderr_bytes : List(U8), stdout_bytes : List(U8) }, [FailedToGetExitCode(IOErr), NonZeroExitCode({ exit_code : I32, stderr_bytes : List(U8), stdout_bytes : List(U8) })])
 /// Refcounted fields are owned by the hosted function.
 #[cfg(target_pointer_width = "32")]
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct HostCmdExecOutputArgs {
+    pub output_limit: u64,
+    pub pending_limit: u64,
+    pub timeout_ms: u64,
     pub args: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub cwd: RocList<UnixBytesOrUtf8OrWindowsU16s>,
     pub envs: RocList<UnixBytesOrUtf8OrWindowsU16s>,
     pub program: UnixBytesOrUtf8OrWindowsU16s,
+    pub stdin_bytes: RocListWith<u8, false>,
     pub clear_envs: bool,
+    pub manage_tree: bool,
+    pub merge_stderr: bool,
+    pub stderr_mode: u8,
+    pub stdin_mode: u8,
+    pub stdout_mode: u8,
 }
 
 /// Arguments for Host.cmd_exec_output!
-/// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] } => Try({ stderr_bytes : List(U8), stdout_bytes : List(U8) }, [FailedToGetExitCode(IOErr), NonZeroExitCode({ exit_code : I32, stderr_bytes : List(U8), stdout_bytes : List(U8) })])
+/// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, cwd : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), manage_tree : Bool, merge_stderr : Bool, output_limit : U64, pending_limit : U64, program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], stderr_mode : U8, stdin_bytes : List(U8), stdin_mode : U8, stdout_mode : U8, timeout_ms : U64 } => Try({ stderr_bytes : List(U8), stdout_bytes : List(U8) }, [FailedToGetExitCode(IOErr), NonZeroExitCode({ exit_code : I32, stderr_bytes : List(U8), stdout_bytes : List(U8) })])
 /// Refcounted fields are owned by the hosted function.
 #[cfg(not(target_pointer_width = "32"))]
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct HostCmdExecOutputArgs {
+    pub output_limit: u64,
+    pub pending_limit: u64,
+    pub timeout_ms: u64,
     pub args: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub cwd: RocList<UnixBytesOrUtf8OrWindowsU16s>,
     pub envs: RocList<UnixBytesOrUtf8OrWindowsU16s>,
     pub program: UnixBytesOrUtf8OrWindowsU16s,
+    pub stdin_bytes: RocListWith<u8, false>,
     pub clear_envs: bool,
+    pub manage_tree: bool,
+    pub merge_stderr: bool,
+    pub stderr_mode: u8,
+    pub stdin_mode: u8,
+    pub stdout_mode: u8,
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<HostCmdExecOutputArgs>() == 88, "HostCmdExecOutputArgs size mismatch");
+const _: () = assert!(core::mem::size_of::<HostCmdExecOutputArgs>() == 160, "HostCmdExecOutputArgs size mismatch");
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(core::mem::align_of::<HostCmdExecOutputArgs>() == 8, "HostCmdExecOutputArgs alignment mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::size_of::<HostCmdExecOutputArgs>() == 44, "HostCmdExecOutputArgs size mismatch");
+const _: () = assert!(core::mem::size_of::<HostCmdExecOutputArgs>() == 96, "HostCmdExecOutputArgs size mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::align_of::<HostCmdExecOutputArgs>() == 4, "HostCmdExecOutputArgs alignment mismatch");
+const _: () = assert!(core::mem::align_of::<HostCmdExecOutputArgs>() == 8, "HostCmdExecOutputArgs alignment mismatch");
 
 impl HostCmdExecOutputArgs {
     /// Recursively decrement Roc-owned fields.
@@ -6810,8 +8133,10 @@ impl HostCmdExecOutputArgs {
     pub unsafe fn decref(self, roc_host: &RocHost) {
         let value = self;
         unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(value.args, roc_host); }
+        unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(value.cwd, roc_host); }
         unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(value.envs, roc_host); }
         unsafe { value.program.decref(roc_host); }
+        unsafe { value.stdin_bytes.decref(roc_host); }
     }
 
     /// Increment Roc-owned fields.
@@ -6822,8 +8147,10 @@ impl HostCmdExecOutputArgs {
     pub unsafe fn incref(self, amount: isize) {
         let value = self;
         unsafe { value.args.incref(amount); }
+        unsafe { value.cwd.incref(amount); }
         unsafe { value.envs.incref(amount); }
         unsafe { value.program.incref(amount); }
+        unsafe { value.stdin_bytes.incref(amount); }
     }
 }
 
@@ -7306,19 +8633,373 @@ pub struct HostEnvSetCwdArgs {
     pub arg0: UnixBytesOrUtf8OrWindowsU16s,
 }
 
+/// Arguments for Host.path_copy!
+/// Roc signature: [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] => Try({}, { destination : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], error : IOErr, operation : Str, source : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] })
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostPathCopyArgs {
+    pub arg0: UnixBytesOrUtf8OrWindowsU16s,
+    pub arg1: UnixBytesOrUtf8OrWindowsU16s,
+}
+
+/// Arguments for Host.path_copy_dir!
+/// Roc signature: [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], { destination : [Merge, RequireNew], symlinks : [Follow, Preserve] } => Try({}, { destination : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], error : IOErr, operation : Str, source : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] })
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostPathCopyDirArgs {
+    pub arg0: UnixBytesOrUtf8OrWindowsU16s,
+    pub arg1: UnixBytesOrUtf8OrWindowsU16s,
+    pub arg2: AnonStructDee0b5b198beef56,
+}
+
+/// Arguments for Host.path_absolute!
+/// Roc signature: [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] => Try([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], IOErr)
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostPathAbsoluteArgs {
+    pub arg0: UnixBytesOrUtf8OrWindowsU16s,
+}
+
+/// Arguments for Host.path_canonicalize!
+/// Roc signature: [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] => Try([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], IOErr)
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostPathCanonicalizeArgs {
+    pub arg0: UnixBytesOrUtf8OrWindowsU16s,
+}
+
+/// Arguments for Host.env_create_temp_dir!
+/// Roc signature: [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], Str => Try([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], IOErr)
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostEnvCreateTempDirArgs {
+    pub arg0: UnixBytesOrUtf8OrWindowsU16s,
+    pub arg1: RocStr,
+}
+
+/// Arguments for Host.cmd_spawn!
+/// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, cwd : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), manage_tree : Bool, merge_stderr : Bool, output_limit : U64, pending_limit : U64, program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], stderr_mode : U8, stdin_bytes : List(U8), stdin_mode : U8, stdout_mode : U8, timeout_ms : U64 } => Try(Host.Child, IOErr)
+/// Refcounted fields are owned by the hosted function.
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostCmdSpawnArgs {
+    pub output_limit: u64,
+    pub pending_limit: u64,
+    pub timeout_ms: u64,
+    pub args: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub cwd: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub envs: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub program: UnixBytesOrUtf8OrWindowsU16s,
+    pub stdin_bytes: RocListWith<u8, false>,
+    pub clear_envs: bool,
+    pub manage_tree: bool,
+    pub merge_stderr: bool,
+    pub stderr_mode: u8,
+    pub stdin_mode: u8,
+    pub stdout_mode: u8,
+}
+
+/// Arguments for Host.cmd_spawn!
+/// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, cwd : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), manage_tree : Bool, merge_stderr : Bool, output_limit : U64, pending_limit : U64, program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], stderr_mode : U8, stdin_bytes : List(U8), stdin_mode : U8, stdout_mode : U8, timeout_ms : U64 } => Try(Host.Child, IOErr)
+/// Refcounted fields are owned by the hosted function.
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostCmdSpawnArgs {
+    pub output_limit: u64,
+    pub pending_limit: u64,
+    pub timeout_ms: u64,
+    pub args: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub cwd: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub envs: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub program: UnixBytesOrUtf8OrWindowsU16s,
+    pub stdin_bytes: RocListWith<u8, false>,
+    pub clear_envs: bool,
+    pub manage_tree: bool,
+    pub merge_stderr: bool,
+    pub stderr_mode: u8,
+    pub stdin_mode: u8,
+    pub stdout_mode: u8,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<HostCmdSpawnArgs>() == 160, "HostCmdSpawnArgs size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<HostCmdSpawnArgs>() == 8, "HostCmdSpawnArgs alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<HostCmdSpawnArgs>() == 96, "HostCmdSpawnArgs size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<HostCmdSpawnArgs>() == 8, "HostCmdSpawnArgs alignment mismatch");
+
+impl HostCmdSpawnArgs {
+    /// Recursively decrement Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted field.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let value = self;
+        unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(value.args, roc_host); }
+        unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(value.cwd, roc_host); }
+        unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(value.envs, roc_host); }
+        unsafe { value.program.decref(roc_host); }
+        unsafe { value.stdin_bytes.decref(roc_host); }
+    }
+
+    /// Increment Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        unsafe { value.args.incref(amount); }
+        unsafe { value.cwd.incref(amount); }
+        unsafe { value.envs.incref(amount); }
+        unsafe { value.program.incref(amount); }
+        unsafe { value.stdin_bytes.incref(amount); }
+    }
+}
+
+pub struct HostCmdSpawnArgsRelease;
+
+unsafe impl RocRelease<HostCmdSpawnArgs> for HostCmdSpawnArgsRelease {
+    unsafe fn release(value: HostCmdSpawnArgs, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+/// Arguments for Host.cmd_run!
+/// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, cwd : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), manage_tree : Bool, merge_stderr : Bool, output_limit : U64, pending_limit : U64, program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], stderr_mode : U8, stdin_bytes : List(U8), stdin_mode : U8, stdout_mode : U8, timeout_ms : U64 } => Try({ exit_code : I32, failure : U8, signal : I32, stderr_bytes : List(U8), stdout_bytes : List(U8) }, IOErr)
+/// Refcounted fields are owned by the hosted function.
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostCmdRunArgs {
+    pub output_limit: u64,
+    pub pending_limit: u64,
+    pub timeout_ms: u64,
+    pub args: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub cwd: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub envs: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub program: UnixBytesOrUtf8OrWindowsU16s,
+    pub stdin_bytes: RocListWith<u8, false>,
+    pub clear_envs: bool,
+    pub manage_tree: bool,
+    pub merge_stderr: bool,
+    pub stderr_mode: u8,
+    pub stdin_mode: u8,
+    pub stdout_mode: u8,
+}
+
+/// Arguments for Host.cmd_run!
+/// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, cwd : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), manage_tree : Bool, merge_stderr : Bool, output_limit : U64, pending_limit : U64, program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], stderr_mode : U8, stdin_bytes : List(U8), stdin_mode : U8, stdout_mode : U8, timeout_ms : U64 } => Try({ exit_code : I32, failure : U8, signal : I32, stderr_bytes : List(U8), stdout_bytes : List(U8) }, IOErr)
+/// Refcounted fields are owned by the hosted function.
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostCmdRunArgs {
+    pub output_limit: u64,
+    pub pending_limit: u64,
+    pub timeout_ms: u64,
+    pub args: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub cwd: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub envs: RocList<UnixBytesOrUtf8OrWindowsU16s>,
+    pub program: UnixBytesOrUtf8OrWindowsU16s,
+    pub stdin_bytes: RocListWith<u8, false>,
+    pub clear_envs: bool,
+    pub manage_tree: bool,
+    pub merge_stderr: bool,
+    pub stderr_mode: u8,
+    pub stdin_mode: u8,
+    pub stdout_mode: u8,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<HostCmdRunArgs>() == 160, "HostCmdRunArgs size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<HostCmdRunArgs>() == 8, "HostCmdRunArgs alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<HostCmdRunArgs>() == 96, "HostCmdRunArgs size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<HostCmdRunArgs>() == 8, "HostCmdRunArgs alignment mismatch");
+
+impl HostCmdRunArgs {
+    /// Recursively decrement Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted field.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let value = self;
+        unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(value.args, roc_host); }
+        unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(value.cwd, roc_host); }
+        unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(value.envs, roc_host); }
+        unsafe { value.program.decref(roc_host); }
+        unsafe { value.stdin_bytes.decref(roc_host); }
+    }
+
+    /// Increment Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        unsafe { value.args.incref(amount); }
+        unsafe { value.cwd.incref(amount); }
+        unsafe { value.envs.incref(amount); }
+        unsafe { value.program.incref(amount); }
+        unsafe { value.stdin_bytes.incref(amount); }
+    }
+}
+
+pub struct HostCmdRunArgsRelease;
+
+unsafe impl RocRelease<HostCmdRunArgs> for HostCmdRunArgsRelease {
+    unsafe fn release(value: HostCmdRunArgs, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+/// Arguments for Host.child_pid!
+/// Roc signature: Host.Child => Try(U32, IOErr)
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostChildPidArgs {
+    pub arg0: *mut u64,
+}
+
+/// Arguments for Host.child_wait!
+/// Roc signature: Host.Child => Try({ exit_code : I32, failure : U8, signal : I32, stderr_bytes : List(U8), stdout_bytes : List(U8) }, IOErr)
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostChildWaitArgs {
+    pub arg0: *mut u64,
+}
+
+/// Arguments for Host.child_try_wait!
+/// Roc signature: Host.Child => Try(List({ exit_code : I32, failure : U8, signal : I32, stderr_bytes : List(U8), stdout_bytes : List(U8) }), IOErr)
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostChildTryWaitArgs {
+    pub arg0: *mut u64,
+}
+
+/// Arguments for Host.child_kill!
+/// Roc signature: Host.Child => Try({}, IOErr)
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostChildKillArgs {
+    pub arg0: *mut u64,
+}
+
+/// Arguments for Host.child_close!
+/// Roc signature: Host.Child => Try({}, IOErr)
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostChildCloseArgs {
+    pub arg0: *mut u64,
+}
+
+/// Arguments for Host.child_close_stdin!
+/// Roc signature: Host.Child => Try({}, IOErr)
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostChildCloseStdinArgs {
+    pub arg0: *mut u64,
+}
+
+/// Arguments for Host.child_write!
+/// Roc signature: Host.Child, List(U8), U64 => Try({}, IOErr)
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostChildWriteArgs {
+    pub arg0: *mut u64,
+    pub arg1: RocListWith<u8, false>,
+    pub arg2: u64,
+}
+
+/// Arguments for Host.child_read!
+/// Roc signature: Host.Child, U64, U64 => Try({ bytes : List(U8), stream : U8 }, IOErr)
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostChildReadArgs {
+    pub arg0: *mut u64,
+    pub arg1: u64,
+    pub arg2: u64,
+}
+
+/// Arguments for Host.tcp_listen!
+/// Roc signature: Str, U16, U64 => Try(Host.TcpListener, Str)
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostTcpListenArgs {
+    pub arg0: RocStr,
+    pub arg1: u16,
+    pub arg2: u64,
+}
+
+/// Arguments for Host.tcp_local_port!
+/// Roc signature: Host.TcpListener => Try(U16, Str)
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostTcpLocalPortArgs {
+    pub arg0: *mut u64,
+}
+
+/// Arguments for Host.tcp_accept!
+/// Roc signature: Host.TcpListener, U64 => Try(Host.TcpStream, Str)
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostTcpAcceptArgs {
+    pub arg0: *mut u64,
+    pub arg1: u64,
+}
+
+/// Arguments for Host.tcp_listener_close!
+/// Roc signature: Host.TcpListener => Try({}, Str)
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostTcpListenerCloseArgs {
+    pub arg0: *mut u64,
+}
+
 // Platform Type Aliases
 
-pub type HostCmdExecExitCodeArg0 = AnonStruct32ddec9aa3de7110;
+pub type HostCmdExecExitCodeArg0 = AnonStructB57902ff7f66e961;
 pub type HostCmdExecExitCodeArg0Args = UnixBytesOrUtf8OrWindowsU16s;
 pub type HostCmdExecExitCodeArg0ArgsPayload = UnixBytesOrUtf8OrWindowsU16sPayload;
 pub type HostCmdExecExitCodeArg0ArgsTag = UnixBytesOrUtf8OrWindowsU16sTag;
+pub type HostCmdExecExitCodeArg0Cwd = UnixBytesOrUtf8OrWindowsU16s;
+pub type HostCmdExecExitCodeArg0CwdPayload = UnixBytesOrUtf8OrWindowsU16sPayload;
+pub type HostCmdExecExitCodeArg0CwdTag = UnixBytesOrUtf8OrWindowsU16sTag;
 pub type HostCmdExecExitCodeArg0Envs = UnixBytesOrUtf8OrWindowsU16s;
 pub type HostCmdExecExitCodeArg0EnvsPayload = UnixBytesOrUtf8OrWindowsU16sPayload;
 pub type HostCmdExecExitCodeArg0EnvsTag = UnixBytesOrUtf8OrWindowsU16sTag;
-pub type HostCmdExecOutputArg0 = AnonStruct32ddec9aa3de7110;
+pub type HostCmdExecOutputArg0 = AnonStructB57902ff7f66e961;
 pub type HostCmdExecOutputArg0Args = UnixBytesOrUtf8OrWindowsU16s;
 pub type HostCmdExecOutputArg0ArgsPayload = UnixBytesOrUtf8OrWindowsU16sPayload;
 pub type HostCmdExecOutputArg0ArgsTag = UnixBytesOrUtf8OrWindowsU16sTag;
+pub type HostCmdExecOutputArg0Cwd = UnixBytesOrUtf8OrWindowsU16s;
+pub type HostCmdExecOutputArg0CwdPayload = UnixBytesOrUtf8OrWindowsU16sPayload;
+pub type HostCmdExecOutputArg0CwdTag = UnixBytesOrUtf8OrWindowsU16sTag;
 pub type HostCmdExecOutputArg0Envs = UnixBytesOrUtf8OrWindowsU16s;
 pub type HostCmdExecOutputArg0EnvsPayload = UnixBytesOrUtf8OrWindowsU16sPayload;
 pub type HostCmdExecOutputArg0EnvsTag = UnixBytesOrUtf8OrWindowsU16sTag;
@@ -7431,6 +9112,72 @@ pub type HostHttpSendRequestOk = AnonStructBe6bcbc15f8a1360;
 pub type HostHttpSendRequestOkHeaders = AnonStruct77eaba63dfee299d;
 pub type HostEnvPlatform = AnonStructBca0d23b5d625934;
 pub type HostEnvDict = AnonStruct69eee2ff6c448fed;
+pub type HostPathCopyErr = AnonStruct75cf0dfdbccd3932;
+pub type HostPathCopyDirArg2 = AnonStructDee0b5b198beef56;
+pub type HostPathCopyDirResult = HostPathCopyResult;
+pub type HostPathCopyDirResultPayload = HostPathCopyResultPayload;
+pub type HostPathCopyDirResultTag = HostPathCopyResultTag;
+pub type HostPathCopyDirErr = AnonStruct75cf0dfdbccd3932;
+pub type HostPathAbsoluteOk = UnixBytesOrUtf8OrWindowsU16s;
+pub type HostPathAbsoluteOkPayload = UnixBytesOrUtf8OrWindowsU16sPayload;
+pub type HostPathAbsoluteOkTag = UnixBytesOrUtf8OrWindowsU16sTag;
+pub type HostPathCanonicalizeResult = HostPathAbsoluteResult;
+pub type HostPathCanonicalizeResultPayload = HostPathAbsoluteResultPayload;
+pub type HostPathCanonicalizeResultTag = HostPathAbsoluteResultTag;
+pub type HostPathCanonicalizeOk = UnixBytesOrUtf8OrWindowsU16s;
+pub type HostPathCanonicalizeOkPayload = UnixBytesOrUtf8OrWindowsU16sPayload;
+pub type HostPathCanonicalizeOkTag = UnixBytesOrUtf8OrWindowsU16sTag;
+pub type HostEnvCreateTempDirResult = HostPathAbsoluteResult;
+pub type HostEnvCreateTempDirResultPayload = HostPathAbsoluteResultPayload;
+pub type HostEnvCreateTempDirResultTag = HostPathAbsoluteResultTag;
+pub type HostEnvCreateTempDirOk = UnixBytesOrUtf8OrWindowsU16s;
+pub type HostEnvCreateTempDirOkPayload = UnixBytesOrUtf8OrWindowsU16sPayload;
+pub type HostEnvCreateTempDirOkTag = UnixBytesOrUtf8OrWindowsU16sTag;
+pub type HostCmdSpawnArg0 = AnonStructB57902ff7f66e961;
+pub type HostCmdSpawnArg0Args = UnixBytesOrUtf8OrWindowsU16s;
+pub type HostCmdSpawnArg0ArgsPayload = UnixBytesOrUtf8OrWindowsU16sPayload;
+pub type HostCmdSpawnArg0ArgsTag = UnixBytesOrUtf8OrWindowsU16sTag;
+pub type HostCmdSpawnArg0Cwd = UnixBytesOrUtf8OrWindowsU16s;
+pub type HostCmdSpawnArg0CwdPayload = UnixBytesOrUtf8OrWindowsU16sPayload;
+pub type HostCmdSpawnArg0CwdTag = UnixBytesOrUtf8OrWindowsU16sTag;
+pub type HostCmdSpawnArg0Envs = UnixBytesOrUtf8OrWindowsU16s;
+pub type HostCmdSpawnArg0EnvsPayload = UnixBytesOrUtf8OrWindowsU16sPayload;
+pub type HostCmdSpawnArg0EnvsTag = UnixBytesOrUtf8OrWindowsU16sTag;
+pub type HostCmdRunArg0 = AnonStructB57902ff7f66e961;
+pub type HostCmdRunArg0Args = UnixBytesOrUtf8OrWindowsU16s;
+pub type HostCmdRunArg0ArgsPayload = UnixBytesOrUtf8OrWindowsU16sPayload;
+pub type HostCmdRunArg0ArgsTag = UnixBytesOrUtf8OrWindowsU16sTag;
+pub type HostCmdRunArg0Cwd = UnixBytesOrUtf8OrWindowsU16s;
+pub type HostCmdRunArg0CwdPayload = UnixBytesOrUtf8OrWindowsU16sPayload;
+pub type HostCmdRunArg0CwdTag = UnixBytesOrUtf8OrWindowsU16sTag;
+pub type HostCmdRunArg0Envs = UnixBytesOrUtf8OrWindowsU16s;
+pub type HostCmdRunArg0EnvsPayload = UnixBytesOrUtf8OrWindowsU16sPayload;
+pub type HostCmdRunArg0EnvsTag = UnixBytesOrUtf8OrWindowsU16sTag;
+pub type HostCmdRunOk = AnonStructDa30c5358d228170;
+pub type HostChildWaitResult = HostCmdRunResult;
+pub type HostChildWaitResultPayload = HostCmdRunResultPayload;
+pub type HostChildWaitResultTag = HostCmdRunResultTag;
+pub type HostChildWaitOk = AnonStructDa30c5358d228170;
+pub type HostChildTryWaitOk = AnonStructDa30c5358d228170;
+pub type HostChildKillResult = HostEnvSetCwdResult;
+pub type HostChildKillResultPayload = HostEnvSetCwdResultPayload;
+pub type HostChildKillResultTag = HostEnvSetCwdResultTag;
+pub type HostChildCloseResult = HostEnvSetCwdResult;
+pub type HostChildCloseResultPayload = HostEnvSetCwdResultPayload;
+pub type HostChildCloseResultTag = HostEnvSetCwdResultTag;
+pub type HostChildCloseStdinResult = HostEnvSetCwdResult;
+pub type HostChildCloseStdinResultPayload = HostEnvSetCwdResultPayload;
+pub type HostChildCloseStdinResultTag = HostEnvSetCwdResultTag;
+pub type HostChildWriteResult = HostEnvSetCwdResult;
+pub type HostChildWriteResultPayload = HostEnvSetCwdResultPayload;
+pub type HostChildWriteResultTag = HostEnvSetCwdResultTag;
+pub type HostChildReadOk = AnonStruct90571bef66942268;
+pub type HostTcpAcceptResult = HostTcpConnectResult;
+pub type HostTcpAcceptResultPayload = HostTcpConnectResultPayload;
+pub type HostTcpAcceptResultTag = HostTcpConnectResultTag;
+pub type HostTcpListenerCloseResult = HostTcpWriteResult;
+pub type HostTcpListenerCloseResultPayload = HostTcpWriteResultPayload;
+pub type HostTcpListenerCloseResultTag = HostTcpWriteResultTag;
 pub type MainForHostArg0 = OsStr;
 pub type MainForHostArg0Payload = OsStrPayload;
 pub type MainForHostArg0Tag = OsStrTag;
@@ -7539,7 +9286,7 @@ unsafe impl RocRelease<HostIOErr> for HostIOErrRelease {
     }
 }
 
-impl AnonStruct32ddec9aa3de7110 {
+impl AnonStructB57902ff7f66e961 {
     /// Recursively decrement Roc-owned fields.
     ///
     /// # Safety
@@ -7547,8 +9294,10 @@ impl AnonStruct32ddec9aa3de7110 {
     pub unsafe fn decref(self, roc_host: &RocHost) {
         let value = self;
         unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(value.args, roc_host); }
+        unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(value.cwd, roc_host); }
         unsafe { decref_list_of_unix_bytes_or_utf8or_windows_u16s(value.envs, roc_host); }
         unsafe { value.program.decref(roc_host); }
+        unsafe { value.stdin_bytes.decref(roc_host); }
     }
 
     /// Increment Roc-owned fields.
@@ -7559,15 +9308,17 @@ impl AnonStruct32ddec9aa3de7110 {
     pub unsafe fn incref(self, amount: isize) {
         let value = self;
         unsafe { value.args.incref(amount); }
+        unsafe { value.cwd.incref(amount); }
         unsafe { value.envs.incref(amount); }
         unsafe { value.program.incref(amount); }
+        unsafe { value.stdin_bytes.incref(amount); }
     }
 }
 
-pub struct AnonStruct32ddec9aa3de7110Release;
+pub struct AnonStructB57902ff7f66e961Release;
 
-unsafe impl RocRelease<AnonStruct32ddec9aa3de7110> for AnonStruct32ddec9aa3de7110Release {
-    unsafe fn release(value: AnonStruct32ddec9aa3de7110, roc_host: &RocHost) {
+unsafe impl RocRelease<AnonStructB57902ff7f66e961> for AnonStructB57902ff7f66e961Release {
+    unsafe fn release(value: AnonStructB57902ff7f66e961, roc_host: &RocHost) {
         unsafe { value.decref(roc_host); }
     }
 }
@@ -9797,6 +11548,613 @@ unsafe impl RocRelease<HostEnvSetCwdResult> for HostEnvSetCwdResultRelease {
     }
 }
 
+impl HostPathCopyResult {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let mut value = self;
+        let _ = roc_host;
+        match value.tag {
+            HostPathCopyResultTag::Err => {
+                let payload = unsafe { value.take_payload_err_unchecked() };
+                unsafe { payload.decref(roc_host); }
+            },
+            HostPathCopyResultTag::Ok => {},
+        }
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        let _ = amount;
+        match value.tag {
+            HostPathCopyResultTag::Err => {
+                let payload = unsafe { core::ptr::read(value.borrow_payload_err_unchecked()) };
+                unsafe { payload.incref(amount); }
+            },
+            HostPathCopyResultTag::Ok => {},
+        }
+    }
+}
+
+pub struct HostPathCopyResultRelease;
+
+unsafe impl RocRelease<HostPathCopyResult> for HostPathCopyResultRelease {
+    unsafe fn release(value: HostPathCopyResult, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+impl AnonStruct75cf0dfdbccd3932 {
+    /// Recursively decrement Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted field.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let value = self;
+        unsafe { value.destination.decref(roc_host); }
+        unsafe { value.error.decref(roc_host); }
+        unsafe { value.operation.decref(roc_host); }
+        unsafe { value.source.decref(roc_host); }
+    }
+
+    /// Increment Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        unsafe { value.destination.incref(amount); }
+        unsafe { value.error.incref(amount); }
+        unsafe { value.operation.incref(amount); }
+        unsafe { value.source.incref(amount); }
+    }
+}
+
+pub struct AnonStruct75cf0dfdbccd3932Release;
+
+unsafe impl RocRelease<AnonStruct75cf0dfdbccd3932> for AnonStruct75cf0dfdbccd3932Release {
+    unsafe fn release(value: AnonStruct75cf0dfdbccd3932, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+impl AnonStructDee0b5b198beef56 {
+    /// Recursively decrement Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted field.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let value = self;
+        unsafe { value.destination.decref(roc_host); }
+        unsafe { value.symlinks.decref(roc_host); }
+    }
+
+    /// Increment Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        unsafe { value.destination.incref(amount); }
+        unsafe { value.symlinks.incref(amount); }
+    }
+}
+
+pub struct AnonStructDee0b5b198beef56Release;
+
+unsafe impl RocRelease<AnonStructDee0b5b198beef56> for AnonStructDee0b5b198beef56Release {
+    unsafe fn release(value: AnonStructDee0b5b198beef56, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+impl MergeOrRequireNew {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let _ = self;
+        let _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let _ = self;
+        let _ = amount;
+    }
+}
+
+pub struct MergeOrRequireNewRelease;
+
+unsafe impl RocRelease<MergeOrRequireNew> for MergeOrRequireNewRelease {
+    unsafe fn release(value: MergeOrRequireNew, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+impl FollowOrPreserve {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let _ = self;
+        let _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let _ = self;
+        let _ = amount;
+    }
+}
+
+pub struct FollowOrPreserveRelease;
+
+unsafe impl RocRelease<FollowOrPreserve> for FollowOrPreserveRelease {
+    unsafe fn release(value: FollowOrPreserve, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+impl HostPathAbsoluteResult {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let mut value = self;
+        let _ = roc_host;
+        match value.tag {
+            HostPathAbsoluteResultTag::Err => {
+                let payload = unsafe { value.take_payload_err_unchecked() };
+                unsafe { payload.decref(roc_host); }
+            },
+            HostPathAbsoluteResultTag::Ok => {
+                let payload = unsafe { value.take_payload_ok_unchecked() };
+                unsafe { payload.decref(roc_host); }
+            },
+        }
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        let _ = amount;
+        match value.tag {
+            HostPathAbsoluteResultTag::Err => {
+                let payload = unsafe { core::ptr::read(value.borrow_payload_err_unchecked()) };
+                unsafe { payload.incref(amount); }
+            },
+            HostPathAbsoluteResultTag::Ok => {
+                let payload = unsafe { core::ptr::read(value.borrow_payload_ok_unchecked()) };
+                unsafe { payload.incref(amount); }
+            },
+        }
+    }
+}
+
+pub struct HostPathAbsoluteResultRelease;
+
+unsafe impl RocRelease<HostPathAbsoluteResult> for HostPathAbsoluteResultRelease {
+    unsafe fn release(value: HostPathAbsoluteResult, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+impl HostCmdSpawnResult {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let mut value = self;
+        let _ = roc_host;
+        match value.tag {
+            HostCmdSpawnResultTag::Err => {
+                let payload = unsafe { value.take_payload_err_unchecked() };
+                unsafe { payload.decref(roc_host); }
+            },
+            HostCmdSpawnResultTag::Ok => {
+                let payload = unsafe { value.take_payload_ok_unchecked() };
+                unsafe { decref_box_with(payload as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
+            },
+        }
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        let _ = amount;
+        match value.tag {
+            HostCmdSpawnResultTag::Err => {
+                let payload = unsafe { core::ptr::read(value.borrow_payload_err_unchecked()) };
+                unsafe { payload.incref(amount); }
+            },
+            HostCmdSpawnResultTag::Ok => {
+                let payload = unsafe { core::ptr::read(value.borrow_payload_ok_unchecked()) };
+                unsafe { incref_box(payload as RocBox, amount); }
+            },
+        }
+    }
+}
+
+pub struct HostCmdSpawnResultRelease;
+
+unsafe impl RocRelease<HostCmdSpawnResult> for HostCmdSpawnResultRelease {
+    unsafe fn release(value: HostCmdSpawnResult, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+impl HostCmdRunResult {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let mut value = self;
+        let _ = roc_host;
+        match value.tag {
+            HostCmdRunResultTag::Err => {
+                let payload = unsafe { value.take_payload_err_unchecked() };
+                unsafe { payload.decref(roc_host); }
+            },
+            HostCmdRunResultTag::Ok => {
+                let payload = unsafe { value.take_payload_ok_unchecked() };
+                unsafe { payload.decref(roc_host); }
+            },
+        }
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        let _ = amount;
+        match value.tag {
+            HostCmdRunResultTag::Err => {
+                let payload = unsafe { core::ptr::read(value.borrow_payload_err_unchecked()) };
+                unsafe { payload.incref(amount); }
+            },
+            HostCmdRunResultTag::Ok => {
+                let payload = unsafe { core::ptr::read(value.borrow_payload_ok_unchecked()) };
+                unsafe { payload.incref(amount); }
+            },
+        }
+    }
+}
+
+pub struct HostCmdRunResultRelease;
+
+unsafe impl RocRelease<HostCmdRunResult> for HostCmdRunResultRelease {
+    unsafe fn release(value: HostCmdRunResult, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+impl AnonStructDa30c5358d228170 {
+    /// Recursively decrement Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted field.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let value = self;
+        unsafe { value.stderr_bytes.decref(roc_host); }
+        unsafe { value.stdout_bytes.decref(roc_host); }
+    }
+
+    /// Increment Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        unsafe { value.stderr_bytes.incref(amount); }
+        unsafe { value.stdout_bytes.incref(amount); }
+    }
+}
+
+pub struct AnonStructDa30c5358d228170Release;
+
+unsafe impl RocRelease<AnonStructDa30c5358d228170> for AnonStructDa30c5358d228170Release {
+    unsafe fn release(value: AnonStructDa30c5358d228170, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+impl HostChildPidResult {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let mut value = self;
+        let _ = roc_host;
+        match value.tag {
+            HostChildPidResultTag::Err => {
+                let payload = unsafe { value.take_payload_err_unchecked() };
+                unsafe { payload.decref(roc_host); }
+            },
+            HostChildPidResultTag::Ok => {},
+        }
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        let _ = amount;
+        match value.tag {
+            HostChildPidResultTag::Err => {
+                let payload = unsafe { core::ptr::read(value.borrow_payload_err_unchecked()) };
+                unsafe { payload.incref(amount); }
+            },
+            HostChildPidResultTag::Ok => {},
+        }
+    }
+}
+
+pub struct HostChildPidResultRelease;
+
+unsafe impl RocRelease<HostChildPidResult> for HostChildPidResultRelease {
+    unsafe fn release(value: HostChildPidResult, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+impl HostChildTryWaitResult {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let mut value = self;
+        let _ = roc_host;
+        match value.tag {
+            HostChildTryWaitResultTag::Err => {
+                let payload = unsafe { value.take_payload_err_unchecked() };
+                unsafe { payload.decref(roc_host); }
+            },
+            HostChildTryWaitResultTag::Ok => {
+                let payload = unsafe { value.take_payload_ok_unchecked() };
+                unsafe { decref_list_of_anon_struct_da30c5358d228170(payload, roc_host); }
+            },
+        }
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        let _ = amount;
+        match value.tag {
+            HostChildTryWaitResultTag::Err => {
+                let payload = unsafe { core::ptr::read(value.borrow_payload_err_unchecked()) };
+                unsafe { payload.incref(amount); }
+            },
+            HostChildTryWaitResultTag::Ok => {
+                let payload = unsafe { core::ptr::read(value.borrow_payload_ok_unchecked()) };
+                unsafe { payload.incref(amount); }
+            },
+        }
+    }
+}
+
+pub struct HostChildTryWaitResultRelease;
+
+unsafe impl RocRelease<HostChildTryWaitResult> for HostChildTryWaitResultRelease {
+    unsafe fn release(value: HostChildTryWaitResult, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+impl HostChildReadResult {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let mut value = self;
+        let _ = roc_host;
+        match value.tag {
+            HostChildReadResultTag::Err => {
+                let payload = unsafe { value.take_payload_err_unchecked() };
+                unsafe { payload.decref(roc_host); }
+            },
+            HostChildReadResultTag::Ok => {
+                let payload = unsafe { value.take_payload_ok_unchecked() };
+                unsafe { payload.decref(roc_host); }
+            },
+        }
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        let _ = amount;
+        match value.tag {
+            HostChildReadResultTag::Err => {
+                let payload = unsafe { core::ptr::read(value.borrow_payload_err_unchecked()) };
+                unsafe { payload.incref(amount); }
+            },
+            HostChildReadResultTag::Ok => {
+                let payload = unsafe { core::ptr::read(value.borrow_payload_ok_unchecked()) };
+                unsafe { payload.incref(amount); }
+            },
+        }
+    }
+}
+
+pub struct HostChildReadResultRelease;
+
+unsafe impl RocRelease<HostChildReadResult> for HostChildReadResultRelease {
+    unsafe fn release(value: HostChildReadResult, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+impl AnonStruct90571bef66942268 {
+    /// Recursively decrement Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted field.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let value = self;
+        unsafe { value.bytes.decref(roc_host); }
+    }
+
+    /// Increment Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        unsafe { value.bytes.incref(amount); }
+    }
+}
+
+pub struct AnonStruct90571bef66942268Release;
+
+unsafe impl RocRelease<AnonStruct90571bef66942268> for AnonStruct90571bef66942268Release {
+    unsafe fn release(value: AnonStruct90571bef66942268, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+impl HostTcpListenResult {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let mut value = self;
+        let _ = roc_host;
+        match value.tag {
+            HostTcpListenResultTag::Err => {
+                let payload = unsafe { value.take_payload_err_unchecked() };
+                unsafe { payload.decref(roc_host); }
+            },
+            HostTcpListenResultTag::Ok => {
+                let payload = unsafe { value.take_payload_ok_unchecked() };
+                unsafe { decref_box_with(payload as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
+            },
+        }
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        let _ = amount;
+        match value.tag {
+            HostTcpListenResultTag::Err => {
+                let payload = unsafe { core::ptr::read(value.borrow_payload_err_unchecked()) };
+                unsafe { payload.incref(amount); }
+            },
+            HostTcpListenResultTag::Ok => {
+                let payload = unsafe { core::ptr::read(value.borrow_payload_ok_unchecked()) };
+                unsafe { incref_box(payload as RocBox, amount); }
+            },
+        }
+    }
+}
+
+pub struct HostTcpListenResultRelease;
+
+unsafe impl RocRelease<HostTcpListenResult> for HostTcpListenResultRelease {
+    unsafe fn release(value: HostTcpListenResult, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
+impl HostTcpLocalPortResult {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let mut value = self;
+        let _ = roc_host;
+        match value.tag {
+            HostTcpLocalPortResultTag::Err => {
+                let payload = unsafe { value.take_payload_err_unchecked() };
+                unsafe { payload.decref(roc_host); }
+            },
+            HostTcpLocalPortResultTag::Ok => {},
+        }
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        let _ = amount;
+        match value.tag {
+            HostTcpLocalPortResultTag::Err => {
+                let payload = unsafe { core::ptr::read(value.borrow_payload_err_unchecked()) };
+                unsafe { payload.incref(amount); }
+            },
+            HostTcpLocalPortResultTag::Ok => {},
+        }
+    }
+}
+
+pub struct HostTcpLocalPortResultRelease;
+
+unsafe impl RocRelease<HostTcpLocalPortResult> for HostTcpLocalPortResultRelease {
+    unsafe fn release(value: HostTcpLocalPortResult, roc_host: &RocHost) {
+        unsafe { value.decref(roc_host); }
+    }
+}
+
 impl OsStr {
     /// Recursively decrement Roc-owned payloads.
     ///
@@ -9854,7 +12212,7 @@ unsafe impl RocRelease<OsStr> for OsStrRelease {
     }
 }
 
-impl TryType204 {
+impl TryType259 {
     /// Recursively decrement Roc-owned payloads.
     ///
     /// # Safety
@@ -9863,8 +12221,8 @@ impl TryType204 {
         let value = self;
         let _ = roc_host;
         match value.tag {
-            TryType204Tag::Err => {},
-            TryType204Tag::Ok => {},
+            TryType259Tag::Err => {},
+            TryType259Tag::Ok => {},
         }
     }
 
@@ -9877,16 +12235,16 @@ impl TryType204 {
         let value = self;
         let _ = amount;
         match value.tag {
-            TryType204Tag::Err => {},
-            TryType204Tag::Ok => {},
+            TryType259Tag::Err => {},
+            TryType259Tag::Ok => {},
         }
     }
 }
 
-pub struct TryType204Release;
+pub struct TryType259Release;
 
-unsafe impl RocRelease<TryType204> for TryType204Release {
-    unsafe fn release(value: TryType204, roc_host: &RocHost) {
+unsafe impl RocRelease<TryType259> for TryType259Release {
+    unsafe fn release(value: TryType259, roc_host: &RocHost) {
         unsafe { value.decref(roc_host); }
     }
 }
@@ -9944,6 +12302,17 @@ pub unsafe fn decref_list_of_anon_struct2782504baf739389(value: RocList<AnonStru
 /// `value` must own one live Roc list reference.
 pub unsafe fn decref_list_of_anon_struct69eee2ff6c448fed(value: RocList<AnonStruct69eee2ff6c448fed>, roc_host: &RocHost) {
     unsafe { value.release_with::<AnonStruct69eee2ff6c448fedRelease>(roc_host); }
+}
+
+/// Release one owned reference to a `RocList<AnonStructDa30c5358d228170>`.
+///
+/// The allocation's final reference is claimed atomically before any element
+/// is read, so concurrent owners cannot skip or duplicate element teardown.
+///
+/// # Safety
+/// `value` must own one live Roc list reference.
+pub unsafe fn decref_list_of_anon_struct_da30c5358d228170(value: RocList<AnonStructDa30c5358d228170>, roc_host: &RocHost) {
+    unsafe { value.release_with::<AnonStructDa30c5358d228170Release>(roc_host); }
 }
 
 /// Release one owned reference to a `RocList<OsStr>`.
@@ -10016,7 +12385,7 @@ fn direct_roc_host() -> RocHost {
 #[allow(improper_ctypes)]
 unsafe extern "C" {
     /// Hosted symbol for Host.cmd_exec_exit_code!
-    /// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] } => Try(I32, IOErr)
+    /// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, cwd : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), manage_tree : Bool, merge_stderr : Bool, output_limit : U64, pending_limit : U64, program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], stderr_mode : U8, stdin_bytes : List(U8), stdin_mode : U8, stdout_mode : U8, timeout_ms : U64 } => Try(I32, IOErr)
     /// Owned arguments. Release each exactly once before returning, unless it is
     /// moved into storage or into the result:
     ///     unsafe { arg0.decref(roc_host); }
@@ -10024,7 +12393,7 @@ unsafe extern "C" {
     pub fn hosted_cmd_host_exec_exit_code(arg0: HostCmdExecExitCodeArgs) -> HostCmdExecExitCodeResult;
 
     /// Hosted symbol for Host.cmd_exec_output!
-    /// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] } => Try({ stderr_bytes : List(U8), stdout_bytes : List(U8) }, [FailedToGetExitCode(IOErr), NonZeroExitCode({ exit_code : I32, stderr_bytes : List(U8), stdout_bytes : List(U8) })])
+    /// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, cwd : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), manage_tree : Bool, merge_stderr : Bool, output_limit : U64, pending_limit : U64, program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], stderr_mode : U8, stdin_bytes : List(U8), stdin_mode : U8, stdout_mode : U8, timeout_ms : U64 } => Try({ stderr_bytes : List(U8), stdout_bytes : List(U8) }, [FailedToGetExitCode(IOErr), NonZeroExitCode({ exit_code : I32, stderr_bytes : List(U8), stdout_bytes : List(U8) })])
     /// Owned arguments. Release each exactly once before returning, unless it is
     /// moved into storage or into the result:
     ///     unsafe { arg0.decref(roc_host); }
@@ -10449,6 +12818,167 @@ unsafe extern "C" {
     ///     unsafe { arg0.decref(roc_host); }
     /// The result is owned by Roc: return exactly one owned reference.
     pub fn hosted_env_set_cwd(arg0: UnixBytesOrUtf8OrWindowsU16s) -> HostEnvSetCwdResult;
+
+    /// Hosted symbol for Host.path_copy!
+    /// Roc signature: [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] => Try({}, { destination : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], error : IOErr, operation : Str, source : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] })
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { arg0.decref(roc_host); }
+    ///     unsafe { arg1.decref(roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_path_copy(arg0: UnixBytesOrUtf8OrWindowsU16s, arg1: UnixBytesOrUtf8OrWindowsU16s) -> HostPathCopyResult;
+
+    /// Hosted symbol for Host.path_copy_dir!
+    /// Roc signature: [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], { destination : [Merge, RequireNew], symlinks : [Follow, Preserve] } => Try({}, { destination : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], error : IOErr, operation : Str, source : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] })
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { arg0.decref(roc_host); }
+    ///     unsafe { arg1.decref(roc_host); }
+    ///     unsafe { arg2.decref(roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_path_copy_dir(arg0: UnixBytesOrUtf8OrWindowsU16s, arg1: UnixBytesOrUtf8OrWindowsU16s, arg2: AnonStructDee0b5b198beef56) -> HostPathCopyResult;
+
+    /// Hosted symbol for Host.path_absolute!
+    /// Roc signature: [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] => Try([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], IOErr)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { arg0.decref(roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_path_absolute(arg0: UnixBytesOrUtf8OrWindowsU16s) -> HostPathAbsoluteResult;
+
+    /// Hosted symbol for Host.path_canonicalize!
+    /// Roc signature: [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))] => Try([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], IOErr)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { arg0.decref(roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_path_canonicalize(arg0: UnixBytesOrUtf8OrWindowsU16s) -> HostPathAbsoluteResult;
+
+    /// Hosted symbol for Host.env_create_temp_dir!
+    /// Roc signature: [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], Str => Try([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], IOErr)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { arg0.decref(roc_host); }
+    ///     unsafe { arg1.decref(roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_env_create_temp_dir(arg0: UnixBytesOrUtf8OrWindowsU16s, arg1: RocStr) -> HostPathAbsoluteResult;
+
+    /// Hosted symbol for Host.monotonic_now!
+    /// Roc signature: {} => U64
+    pub fn hosted_monotonic_now() -> u64;
+
+    /// Hosted symbol for Host.cmd_spawn!
+    /// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, cwd : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), manage_tree : Bool, merge_stderr : Bool, output_limit : U64, pending_limit : U64, program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], stderr_mode : U8, stdin_bytes : List(U8), stdin_mode : U8, stdout_mode : U8, timeout_ms : U64 } => Try(Host.Child, IOErr)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { arg0.decref(roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_cmd_spawn(arg0: HostCmdSpawnArgs) -> HostCmdSpawnResult;
+
+    /// Hosted symbol for Host.cmd_run!
+    /// Roc signature: { args : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), clear_envs : Bool, cwd : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), envs : List([UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))]), manage_tree : Bool, merge_stderr : Bool, output_limit : U64, pending_limit : U64, program : [UnixBytes(List(U8)), Utf8(Str), WindowsU16s(List(U16))], stderr_mode : U8, stdin_bytes : List(U8), stdin_mode : U8, stdout_mode : U8, timeout_ms : U64 } => Try({ exit_code : I32, failure : U8, signal : I32, stderr_bytes : List(U8), stdout_bytes : List(U8) }, IOErr)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { arg0.decref(roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_cmd_run(arg0: HostCmdRunArgs) -> HostCmdRunResult;
+
+    /// Hosted symbol for Host.child_pid!
+    /// Roc signature: Host.Child => Try(U32, IOErr)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { decref_box_with(arg0 as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_child_pid(arg0: *mut u64) -> HostChildPidResult;
+
+    /// Hosted symbol for Host.child_wait!
+    /// Roc signature: Host.Child => Try({ exit_code : I32, failure : U8, signal : I32, stderr_bytes : List(U8), stdout_bytes : List(U8) }, IOErr)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { decref_box_with(arg0 as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_child_wait(arg0: *mut u64) -> HostCmdRunResult;
+
+    /// Hosted symbol for Host.child_try_wait!
+    /// Roc signature: Host.Child => Try(List({ exit_code : I32, failure : U8, signal : I32, stderr_bytes : List(U8), stdout_bytes : List(U8) }), IOErr)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { decref_box_with(arg0 as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_child_try_wait(arg0: *mut u64) -> HostChildTryWaitResult;
+
+    /// Hosted symbol for Host.child_kill!
+    /// Roc signature: Host.Child => Try({}, IOErr)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { decref_box_with(arg0 as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_child_kill(arg0: *mut u64) -> HostEnvSetCwdResult;
+
+    /// Hosted symbol for Host.child_close!
+    /// Roc signature: Host.Child => Try({}, IOErr)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { decref_box_with(arg0 as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_child_close(arg0: *mut u64) -> HostEnvSetCwdResult;
+
+    /// Hosted symbol for Host.child_close_stdin!
+    /// Roc signature: Host.Child => Try({}, IOErr)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { decref_box_with(arg0 as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_child_close_stdin(arg0: *mut u64) -> HostEnvSetCwdResult;
+
+    /// Hosted symbol for Host.child_write!
+    /// Roc signature: Host.Child, List(U8), U64 => Try({}, IOErr)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { decref_box_with(arg0 as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
+    ///     unsafe { arg1.decref(roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_child_write(arg0: *mut u64, arg1: RocListWith<u8, false>, arg2: u64) -> HostEnvSetCwdResult;
+
+    /// Hosted symbol for Host.child_read!
+    /// Roc signature: Host.Child, U64, U64 => Try({ bytes : List(U8), stream : U8 }, IOErr)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { decref_box_with(arg0 as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_child_read(arg0: *mut u64, arg1: u64, arg2: u64) -> HostChildReadResult;
+
+    /// Hosted symbol for Host.tcp_listen!
+    /// Roc signature: Str, U16, U64 => Try(Host.TcpListener, Str)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { arg0.decref(roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_tcp_listen(arg0: RocStr, arg1: u16, arg2: u64) -> HostTcpListenResult;
+
+    /// Hosted symbol for Host.tcp_local_port!
+    /// Roc signature: Host.TcpListener => Try(U16, Str)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { decref_box_with(arg0 as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_tcp_local_port(arg0: *mut u64) -> HostTcpLocalPortResult;
+
+    /// Hosted symbol for Host.tcp_accept!
+    /// Roc signature: Host.TcpListener, U64 => Try(Host.TcpStream, Str)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { decref_box_with(arg0 as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_tcp_accept(arg0: *mut u64, arg1: u64) -> HostTcpConnectResult;
+
+    /// Hosted symbol for Host.tcp_listener_close!
+    /// Roc signature: Host.TcpListener => Try({}, Str)
+    /// Owned arguments. Release each exactly once before returning, unless it is
+    /// moved into storage or into the result:
+    ///     unsafe { decref_box_with(arg0 as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
+    /// The result is owned by Roc: return exactly one owned reference.
+    pub fn hosted_tcp_listener_close(arg0: *mut u64) -> HostTcpWriteResult;
 
 }
 

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -6,13 +6,9 @@ use std::rc::{Rc, Weak};
 use crate::roc_platform_abi::*;
 use crate::{roc_host, roc_u8_list_from_slice};
 
-// The generated glue represents the `Host.SqliteStmt` backing `Sqlite.Stmt` as
-// `*mut u64`: a boxed u64 whose value we use to stash a raw `*mut SqliteStatement`. The box is
-// allocated/refcounted with the generated `allocate_box`/`decref_box_with`
-// helpers; teardown (running `sqlite3_finalize`) happens in `drop_sqlite_stmt`
-// when the last reference is released. Each host fn that takes a handle calls
-// `release_sqlite_stmt` before returning to balance the incref Roc performs when
-// the value stays live.
+// The boxed native statement is finalized by the shared resource allocator on
+// final ARC release, whether that release happens in Roc or in a hosted effect.
+// Each effect balances the reference transferred across the ABI.
 
 // Generated value/error/state types (see src/roc_platform_abi.rs).
 type SqliteValue = BytesOrIntegerOrNullOrRealOrString;
@@ -23,7 +19,6 @@ type SqliteBindings = HostSqliteBindArg1;
 type NativePath = UnixBytesOrUtf8OrWindowsU16s;
 type NativePathTag = UnixBytesOrUtf8OrWindowsU16sTag;
 
-const SQLITE_STMT_BOX_ALIGN: usize = core::mem::align_of::<u64>();
 const MAX_CACHED_CONNECTIONS: usize = 16;
 
 #[cfg(test)]
@@ -164,48 +159,17 @@ thread_local! {
 }
 
 fn box_sqlite_stmt(stmt: SqliteStatement, roc_host: &RocHost) -> *mut u64 {
-    let raw: *mut SqliteStatement = Box::into_raw(Box::new(stmt));
-    let boxed = unsafe {
-        allocate_box(
-            core::mem::size_of::<u64>(),
-            SQLITE_STMT_BOX_ALIGN,
-            false,
-            roc_host,
-        )
-    };
-    unsafe {
-        *(boxed as *mut u64) = raw as u64;
-    }
-    boxed as *mut u64
+    crate::resources::box_resource(stmt, roc_host)
 }
 
 unsafe fn sqlite_stmt_ref<'a>(handle: *mut u64) -> &'a mut SqliteStatement {
-    &mut *(*handle as *mut SqliteStatement)
-}
-
-extern "C" fn drop_sqlite_stmt(data_ptr: *mut c_void, _roc_host: *mut RocHost) {
-    unsafe {
-        let raw = *(data_ptr as *mut u64) as *mut SqliteStatement;
-        if !raw.is_null() {
-            drop(Box::from_raw(raw));
-        }
-    }
+    unsafe { crate::resources::resource_ref(handle) }
 }
 
 fn release_sqlite_stmt(handle: *mut u64, roc_host: &RocHost) {
-    unsafe {
-        decref_box_with(
-            handle as RocBox,
-            SQLITE_STMT_BOX_ALIGN,
-            false,
-            Some(drop_sqlite_stmt),
-            roc_host,
-        )
-    };
+    crate::resources::release(handle, roc_host);
 }
 
-// SQLITE_TRANSIENT tells SQLite to make its own copy of bound text/blob data, so
-// we don't have to keep the Roc-owned bytes alive past the bind call.
 fn sqlite_transient() -> Option<unsafe extern "C" fn(*mut c_void)> {
     Some(unsafe {
         core::mem::transmute::<*const c_void, unsafe extern "C" fn(*mut c_void)>(

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,5 +1,4 @@
 use core::mem::ManuallyDrop;
-use std::ffi::c_void;
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::net::{IpAddr, SocketAddr, TcpStream, ToSocketAddrs};
 use std::sync::mpsc;
@@ -9,61 +8,27 @@ use std::time::{Duration, Instant};
 use crate::roc_platform_abi::*;
 use crate::{roc_host, roc_u8_list_from_slice};
 
-// The `Host.TcpStream` backing `Tcp.Stream` is represented by the generated glue
-// as `*mut u64`: a boxed u64 holding a raw `*mut BufReader<TcpStream>`. The box is refcounted
-// with `allocate_box`/`decref_box_with`; closing the socket happens in
-// `drop_tcp_stream` when the last reference is released. Each host fn that takes
-// a handle calls `release_tcp_stream` before returning to balance the incref Roc
-// performs when the stream stays live.
+// Tcp streams use the shared resource allocator so final release in either
+// compiled Roc or a hosted effect closes the native buffered socket.
+// Each effect balances its transferred handle reference before returning.
 //
 // Errors cross the boundary as a `RocStr` carrying either "ErrorKind::<Variant>"
 // (mapped back to a tag union in Tcp.roc), "UnexpectedEof", or "LimitExceeded";
 // the Roc side parses them into the public TCP error tags.
 
-const TCP_STREAM_BOX_ALIGN: usize = core::mem::align_of::<u64>();
-
-fn box_tcp_stream(stream: BufReader<TcpStream>, roc_host: &RocHost) -> *mut u64 {
-    let raw: *mut BufReader<TcpStream> = Box::into_raw(Box::new(stream));
-    let boxed = unsafe {
-        allocate_box(
-            core::mem::size_of::<u64>(),
-            TCP_STREAM_BOX_ALIGN,
-            false,
-            roc_host,
-        )
-    };
-    unsafe {
-        *(boxed as *mut u64) = raw as u64;
-    }
-    boxed as *mut u64
+pub(crate) fn box_tcp_stream(stream: BufReader<TcpStream>, roc_host: &RocHost) -> *mut u64 {
+    crate::resources::box_resource(stream, roc_host)
 }
 
 unsafe fn tcp_stream_ref<'a>(handle: *mut u64) -> &'a mut BufReader<TcpStream> {
-    &mut *(*handle as *mut BufReader<TcpStream>)
-}
-
-extern "C" fn drop_tcp_stream(data_ptr: *mut c_void, _roc_host: *mut RocHost) {
-    unsafe {
-        let raw = *(data_ptr as *mut u64) as *mut BufReader<TcpStream>;
-        if !raw.is_null() {
-            drop(Box::from_raw(raw));
-        }
-    }
+    unsafe { crate::resources::resource_ref(handle) }
 }
 
 fn release_tcp_stream(handle: *mut u64, roc_host: &RocHost) {
-    unsafe {
-        decref_box_with(
-            handle as RocBox,
-            TCP_STREAM_BOX_ALIGN,
-            false,
-            Some(drop_tcp_stream),
-            roc_host,
-        )
-    };
+    crate::resources::release(handle, roc_host);
 }
 
-fn to_tcp_connect_err(err: io::Error, roc_host: &RocHost) -> RocStr {
+pub(crate) fn to_tcp_connect_err(err: io::Error, roc_host: &RocHost) -> RocStr {
     let message = match err.kind() {
         io::ErrorKind::PermissionDenied => "ErrorKind::PermissionDenied".to_string(),
         io::ErrorKind::AddrInUse => "ErrorKind::AddrInUse".to_string(),
@@ -95,7 +60,7 @@ fn timed_out() -> io::Error {
     io::Error::new(io::ErrorKind::TimedOut, "TCP operation timed out")
 }
 
-fn deadline_from_timeout(timeout_ms: u64) -> io::Result<Instant> {
+pub(crate) fn deadline_from_timeout(timeout_ms: u64) -> io::Result<Instant> {
     if timeout_ms == 0 {
         return Err(timed_out());
     }
@@ -105,7 +70,7 @@ fn deadline_from_timeout(timeout_ms: u64) -> io::Result<Instant> {
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "TCP timeout is too large"))
 }
 
-fn remaining_time(deadline: Instant) -> io::Result<Duration> {
+pub(crate) fn remaining_time(deadline: Instant) -> io::Result<Duration> {
     let remaining = deadline
         .checked_duration_since(Instant::now())
         .ok_or_else(timed_out)?;
@@ -116,7 +81,7 @@ fn remaining_time(deadline: Instant) -> io::Result<Duration> {
     }
 }
 
-fn resolve_with_deadline(
+pub(crate) fn resolve_with_deadline(
     host: String,
     port: u16,
     deadline: Instant,

--- a/tests/resource-lifetimes/filesystem-tools.roc
+++ b/tests/resource-lifetimes/filesystem-tools.roc
@@ -1,0 +1,23 @@
+## Package a directory tree in a private workspace and clean it up after use.
+app [main!] { pf: platform "../../platform/main.roc" }
+
+import pf.Env
+import pf.OsStr
+import pf.Path
+import pf.Stdout
+
+main! : List(OsStr) => Try({}, _)
+main! = |_args| Env.with_temp_dir!(
+	|workspace| {
+		source = Path.join(workspace, "source")
+		Path.create_dir!(source)?
+		Path.write_utf8!(Path.join(source, "config.txt"), "ready")?
+		bundle = Path.join(workspace, "bundle")
+		Path.copy_dir!(source, bundle)?
+		Path.copy!(Path.join(bundle, "config.txt"), Path.join(bundle, "backup.txt"))?
+		resolved = Path.canonicalize!(bundle)?
+		contents = Path.read_utf8!(Path.join(resolved, "backup.txt"))?
+		expect contents == "ready"
+		Stdout.line!("Copied files in a private workspace")
+	},
+)

--- a/tests/resource-lifetimes/process-control.roc
+++ b/tests/resource-lifetimes/process-control.roc
@@ -1,0 +1,59 @@
+## Spawn a copy of this executable and exchange byte-preserving pipe data.
+app [main!] { pf: platform "../../platform/main.roc" }
+
+import pf.Cmd
+import pf.Env
+import pf.OsStr
+import pf.Path
+import pf.Stdin
+import pf.Stdout
+
+main! : List(OsStr) => Try({}, _)
+main! = |args| {
+	if args.drop_first(1).map(OsStr.display) == ["--echo-helper"] {
+		bytes = Stdin.read_to_end!()?
+		Stdout.write_bytes!(bytes)?
+		Ok({})
+	} else {
+		executable = Env.exe_path!()?
+		directory = Env.cwd!()?
+		command = Cmd.new(Path.to_os_str(executable))
+			.arg_str("--echo-helper")
+			.cwd(directory)
+			.timeout_ms(5000)
+			.manage_tree(Bool.True)
+
+		# run! captures bytes and represents the exit status explicitly.
+		output = command.stdin(Bytes([0, 42, 255]))
+			.run!() ? |err| RunFailed(err)
+		if output.status != Exited(0) or output.stdout_bytes != [0, 42, 255] {
+			Err(UnexpectedCapture)
+		} else {
+			child = command.stdin(Pipe).stdout(Pipe).stderr(Capture).spawn!() ? |err| SpawnFailed(err)
+			_pid = child.pid!() ? |err| PidFailed(err)
+			child.write!([0, 42, 255], 1000) ? |err| WriteFailed(err)
+			child.close_stdin!() ? |err| CloseStdinFailed(err)
+			bytes = read_all!(child, [])?
+			result = child.wait!() ? |err| WaitFailed(err)
+			child.close!() ? |err| CloseFailed(err)
+			child.close!() ? |err| CloseFailed(err)
+			# The reused command and caller retain their native working-directory path.
+			current = Env.cwd!()?
+			if bytes == [0, 42, 255] and result.status == Exited(0) and Path.display(directory) == Path.display(current) {
+				Stdout.line!("process control passed")?
+				Ok({})
+			} else {
+				Err(UnexpectedPipeOutput)
+			}
+		}
+	}
+}
+
+read_all! : Cmd.Child, List(U8) => Try(List(U8), _)
+read_all! = |child, bytes| {
+	match child.read!(2, 1000) ? |err| ReadFailed(err) {
+		Stdout(chunk) => read_all!(child, bytes.concat(chunk))
+		Stderr(_) => Err(UnexpectedStderr)
+		End => Ok(bytes)
+	}
+}

--- a/tests/resource-lifetimes/resource-lifetime.roc
+++ b/tests/resource-lifetimes/resource-lifetime.roc
@@ -1,0 +1,88 @@
+## Exercise automatic native-resource cleanup across aliases, lists, and early returns.
+app [main!] { pf: platform "../../platform/main.roc" }
+
+import pf.Env
+import pf.File
+import pf.OsStr
+import pf.Path
+import pf.Stdout
+import pf.Tcp
+
+main! : List(OsStr) => Try({}, _)
+main! = |_args| {
+	Env.with_temp_dir!(
+		|workspace| {
+			path = Path.join(workspace, "lines.txt")
+			Path.write_utf8!(path, "first\nsecond\n")?
+			for early in [Bool.False, Bool.True] {
+				match read_aliases!(path, early) {
+					Ok(_) => {}
+					Err(ExpectedEarlyReturn) => {}
+					Err(err) => return Err(err)
+				}
+			}
+			Path.delete!(path)
+		},
+	)?
+
+	for early in [Bool.False, Bool.True] {
+		port = match release_listener!(early) {
+			Ok(released_port) => released_port
+			Err(Released(released_port)) => released_port
+			Err(err) => return Err(err)
+		}
+		# Binding the same exclusive port proves the last Roc reference closed it.
+		rebound = Tcp.listen!("127.0.0.1", port, 5_000)?
+		Tcp.Listener.close!(rebound)?
+		Tcp.Listener.close!(rebound)?
+	}
+
+	listener = Tcp.listen!("127.0.0.1", 0, 5_000)?
+	server = connect_aliases!(listener)?
+	# A live leaked client would time out here. Final ARC release must send EOF.
+	eof = Tcp.Stream.read_up_to!(server, 1, 5_000)?
+	expect eof == []
+	Tcp.Listener.close!(listener)?
+	Stdout.line!("Resource aliases and early returns cleaned up")
+}
+
+read_aliases! = |path, early| {
+	reader = File.open_reader!(path)?
+	aliases = [reader, reader]
+	if early {
+		return Err(ExpectedEarlyReturn)
+	}
+	var lines = []
+	for alias in aliases {
+		lines = List.append(lines, File.Reader.read_line!(alias)?)
+	}
+	expect lines == [Str.to_utf8("first\n"), Str.to_utf8("second\n")]
+	Ok({})
+}
+
+release_listener! = |early| {
+	listener = Tcp.listen!("127.0.0.1", 0, 5_000)?
+	aliases = [listener, listener]
+	port = Tcp.Listener.local_port!(listener)?
+	if early {
+		return Err(Released(port))
+	}
+	for alias in aliases {
+		alias_port = Tcp.Listener.local_port!(alias)?
+		expect alias_port == port
+	}
+	Ok(port)
+}
+
+connect_aliases! = |listener| {
+	port = Tcp.Listener.local_port!(listener)?
+	client = Tcp.connect!("127.0.0.1", port, 5_000)?
+	aliases = [client, client]
+	server = Tcp.Listener.accept!(listener, 5_000)?
+	for alias in aliases {
+		Tcp.Stream.write_utf8!(alias, "x", 5_000)?
+	}
+	bytes = Tcp.Stream.read_exactly!(server, 2, 5_000)?
+	expect bytes == Str.to_utf8("xx")
+	Ok(server)
+}


### PR DESCRIPTION
Basic-cli scripts currently need external tools for directory copying and temporary workspaces, and cannot retain listener ports or manage child-process pipes and deadlines. This adds native filesystem helpers, managed commands, TCP listeners, and monotonic timing for those workflows.

- Add file/tree copy policies, private temporary directories with scoped cleanup, and absolute/canonical paths.
- Add command working directories, spawn/run, configurable streams, bounded capture, interactive pipes, deadlines, and process-tree cleanup. Final Roc references release native resources, including existing file readers, TCP streams, and SQLite statements.
- Add practical examples for preparing a release directory and running a build. Keep ownership regressions in separate fixtures with a glibc/Valgrind CI check.

This changes the host ABI and prepares version 0.23.0. Existing command helpers share the new process engine; captured output now defaults to a combined 16 MiB budget. The compiler pin and generated glue are updated together. Contributor instructions refer to the pin rather than duplicating its value.

Validation: 51 Rust tests pass; generated glue is current; the full Linux source/build/native example suite and three glibc/Valgrind ownership fixtures pass. ARM Linux and both macOS hosts cross-build, and Windows GNU passes a compile check. Native macOS/Windows/ARM execution remains for CI.

Closes #484, closes #485, closes #486, closes #487, closes #488, closes #489.
Also addresses #440, #162, and #476.
